### PR TITLE
fix(stale): add caller permissions, bump v10

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -10,3 +10,6 @@ on:
 jobs:
     prerelease:
         uses: ./.github/workflows/reusable-prerelease.yml
+        permissions:
+            contents: write
+            pull-requests: write

--- a/.github/workflows/reusable-stale.yml
+++ b/.github/workflows/reusable-stale.yml
@@ -27,7 +27,7 @@ jobs:
             issues: write
             pull-requests: write
         steps:
-            - uses: actions/stale@v9
+            - uses: actions/stale@v10
               with:
                   days-before-stale: ${{ inputs.days-before-stale }}
                   days-before-close: ${{ inputs.days-before-close }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -7,3 +7,6 @@ on:
 jobs:
     stale:
         uses: ./.github/workflows/reusable-stale.yml
+        permissions:
+            issues: write
+            pull-requests: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reusable WP E2E test workflow with Playwright
 - Self-referencing CI as built-in integration test
 
+### Fixed
+
+- Stale workflow caller missing permissions (caused startup_failure)
+
 ### Changed
 
 - WP integration workflow uses `wp-phpunit/wp-phpunit` Composer package instead of SVN checkout
+- Upgrade `actions/stale` from v9 to v10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Stale workflow caller missing permissions (caused startup_failure)
+- Stale and prerelease caller workflows missing permissions (caused startup_failure)
 
 ### Changed
 


### PR DESCRIPTION
## Summary

- Add missing `permissions` (issues: write, pull-requests: write) to the stale caller workflow — fixes `startup_failure` on all repos with restricted default token permissions
- Upgrade `actions/stale` from v9 to v10

## Context

Commit 060a577 added permissions to the release and PR validation callers but missed the stale caller. With org-level default token permissions set to read-only, the reusable stale workflow couldn't obtain write access, causing immediate `startup_failure` before any job ran.

Affected repos: reusable-workflows, template-repo, quote-of-the-day, template-wordpress, ddev-orchestrate

**Note:** Consuming repos also need `permissions: issues: write, pull-requests: write` on their stale caller jobs.