### PR TITLE
fix: generate coverage report for integration tests

### DIFF
--- a/.github/workflows/reusable-wp-integration.yml
+++ b/.github/workflows/reusable-wp-integration.yml
@@ -156,13 +156,27 @@ jobs:
                   fi
 
             - name: Run integration tests
-              if: steps.wp-version.outputs.skip != 'true'
+              if: >-
+                  steps.wp-version.outputs.skip != 'true'
+                  && matrix.php != inputs.php-version-coverage
               env:
                   WP_TESTS_DIR: ${{ github.workspace }}/vendor/wp-phpunit/wp-phpunit
                   WP_PHPUNIT__TESTS_CONFIG: ${{ github.workspace }}/wp-tests-config.php
                   WP_CORE_DIR: /tmp/wordpress
                   WP_MULTISITE: ${{ matrix.multisite && '1' || '0' }}
               run: composer ${{ inputs.test-command }}
+
+            - name: Run integration tests with coverage
+              if: >-
+                  steps.wp-version.outputs.skip != 'true'
+                  && matrix.php == inputs.php-version-coverage
+                  && inputs.php-version-coverage != ''
+              env:
+                  WP_TESTS_DIR: ${{ github.workspace }}/vendor/wp-phpunit/wp-phpunit
+                  WP_PHPUNIT__TESTS_CONFIG: ${{ github.workspace }}/wp-tests-config.php
+                  WP_CORE_DIR: /tmp/wordpress
+                  WP_MULTISITE: ${{ matrix.multisite && '1' || '0' }}
+              run: composer ${{ inputs.test-command }} -- --coverage-clover=coverage.xml
 
             - uses: codecov/codecov-action@v5
               if: >-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.1.0] - Unreleased
+## [0.1.1] - 2026-03-19
+
+### Fixed
+
+- Integration workflow: generate `coverage.xml` for coverage PHP version
+
+## [0.1.0] - 2026-03-01
 
 ### Added
 


### PR DESCRIPTION
## Problem

The integration workflow installs pcov for the coverage PHP version but runs
`composer test:integration` without `--coverage-clover=coverage.xml`. The Codecov
upload step expects `coverage.xml` but the file is never generated, so integration
test coverage is silently not reported.

## Fix

Split the test run into two steps (matching `reusable-ci.yml`):
- Without coverage: `composer test:integration`
- With coverage: `composer test:integration -- --coverage-clover=coverage.xml`

Fixes #4