### PR TITLE
feat: v0.2.0 — theme CI, DDEV E2E, labeled WP versions

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,19 @@
+have_fun: true
+
+ignore_patterns:
+  - "vendor/**"
+  - "node_modules/**"
+  - "*.min.js"
+  - "*.min.css"
+  - "package-lock.json"
+  - "composer.lock"
+
+code_review:
+  disable: false
+  comment_severity_threshold: MEDIUM
+  max_review_comments: -1
+  pull_request_opened:
+    help: false
+    summary: true
+    code_review: true
+    include_drafts: true

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -16,7 +16,7 @@ Shared GitHub Actions reusable workflows for all apermo repositories. Each workf
 - All reusable workflows must use `workflow_call` trigger.
 - Inputs should have sensible defaults matching the apermo standard.
 - Secrets must be passed explicitly (never inherited).
-- Action versions must be pinned to major: `@v1`, `@v2`, `@v4`, `@v5`.
+- Action versions must be pinned to major (e.g. `@v4`, not `@v4.1.2` or a SHA).
 - Flag workflows missing `fail-fast: false` on test matrices.
 
 ## File Operations

--- a/.gemini/styleguide.md
+++ b/.gemini/styleguide.md
@@ -1,0 +1,39 @@
+# Code Review Style Guide
+
+## Project Context
+
+Shared GitHub Actions reusable workflows for all apermo repositories. Each workflow is parameterized via
+`workflow_call` inputs and can be called from any repo.
+
+## Code Style
+
+- Flag inline comments that merely restate what the code does instead of explaining intent or reasoning.
+- Flag commented-out code.
+- Flag new code that duplicates existing functionality in the repository.
+
+## GitHub Actions
+
+- All reusable workflows must use `workflow_call` trigger.
+- Inputs should have sensible defaults matching the apermo standard.
+- Secrets must be passed explicitly (never inherited).
+- Action versions must be pinned to major: `@v1`, `@v2`, `@v4`, `@v5`.
+- Flag workflows missing `fail-fast: false` on test matrices.
+
+## File Operations
+
+- Flag files that appear to be deleted and re-added as new files instead of being moved/renamed (losing git
+  history).
+
+## Build & Packaging
+
+- Flag newly added files or directories that are missing from build/packaging configs (`.gitattributes`, `Makefile`,
+  CI workflows, etc.).
+
+## Documentation
+
+- If a change affects user-facing behavior, flag missing updates to README, CHANGELOG, or inline docblocks.
+
+## Commits
+
+- This project uses Conventional Commits with a 50-char subject / 72-char body limit.
+- Each commit should address a single concern.

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -12,3 +12,9 @@ jobs:
             pull-requests: write
     conventional-commits:
         uses: ./.github/workflows/reusable-conventional-commits.yml
+    actionlint:
+        name: Lint workflows
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+            - uses: reviewdog/action-actionlint@v1

--- a/.github/workflows/reusable-conventional-commits.yml
+++ b/.github/workflows/reusable-conventional-commits.yml
@@ -12,7 +12,7 @@ on:
                 description: 'Pipe-separated list of allowed types'
                 required: false
                 type: string
-                default: 'feat|fix|docs|style|refactor|test|chore|perf'
+                default: 'feat|fix|docs|style|refactor|test|chore|perf|ci|build'
 
 jobs:
     validate:

--- a/.github/workflows/reusable-wp-e2e.yml
+++ b/.github/workflows/reusable-wp-e2e.yml
@@ -14,12 +14,12 @@ on:
                 type: string
                 default: '22'
             wp-versions:
-                description: 'JSON array of WP versions (e.g. "latest", "6.7")'
+                description: 'JSON array of WP versions (e.g. "latest", "6.7"). Ignored when use-ddev is true.'
                 required: false
                 type: string
                 default: '["latest"]'
             multisite:
-                description: 'Multisite mode: "none", "both", or "only"'
+                description: 'Multisite mode: "none", "both", or "only". Ignored when use-ddev is true.'
                 required: false
                 type: string
                 default: 'none'
@@ -37,6 +37,7 @@ on:
 jobs:
     matrix-prep:
         name: Prepare matrix
+        if: ${{ !inputs.use-ddev }}
         runs-on: ubuntu-latest
         outputs:
             multisite: ${{ steps.multisite.outputs.matrix }}
@@ -51,6 +52,7 @@ jobs:
 
     e2e:
         name: WP ${{ matrix.wp }}${{ matrix.multisite && ' / multisite' || '' }}
+        if: ${{ !inputs.use-ddev }}
         needs: matrix-prep
         runs-on: ubuntu-latest
         strategy:
@@ -74,23 +76,7 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
-            # ── DDEV path ──
-            - name: Set up DDEV
-              if: inputs.use-ddev
-              uses: ddev/github-action-setup-ddev@v1
-
-            - name: Start DDEV environment
-              if: inputs.use-ddev
-              run: ddev start && ddev orchestrate
-
-            - name: Detect DDEV site URL
-              if: inputs.use-ddev
-              id: ddev-url
-              run: echo "url=$(ddev describe -j | jq -r '.raw.primary_url')" >> "$GITHUB_OUTPUT"
-
-            # ── Standard path ──
             - uses: shivammathur/setup-php@v2
-              if: ${{ !inputs.use-ddev }}
               with:
                   php-version: ${{ inputs.php-version }}
                   extensions: mysqli, intl, mbstring
@@ -98,10 +84,8 @@ jobs:
                   tools: wp-cli
 
             - run: composer install --no-interaction --prefer-dist
-              if: ${{ !inputs.use-ddev }}
 
             - name: Resolve WP version
-              if: ${{ !inputs.use-ddev }}
               id: wp-version
               run: |
                   WP_INPUT="${{ matrix.wp }}"
@@ -114,7 +98,6 @@ jobs:
                   fi
 
             - name: Set up WordPress
-              if: ${{ !inputs.use-ddev }}
               run: |
                   WP_VERSION="${{ steps.wp-version.outputs.version }}"
 
@@ -150,7 +133,6 @@ jobs:
                   fi
 
             - name: Activate project
-              if: ${{ !inputs.use-ddev }}
               run: |
                   PROJECT_NAME=$(basename "${{ github.workspace }}")
                   MODE="${{ inputs.project-mode }}"
@@ -171,21 +153,19 @@ jobs:
                   fi
 
             - name: Start PHP server
-              if: ${{ !inputs.use-ddev }}
               run: php -S 0.0.0.0:8080 -t /tmp/wordpress/ &
 
             - name: Wait for server
-              if: ${{ !inputs.use-ddev }}
               run: |
                   for i in $(seq 1 10); do
                       curl -s http://localhost:8080/ > /dev/null && break
                       sleep 1
                   done
 
-            # ── Shared steps ──
             - uses: actions/setup-node@v4
               with:
                   node-version: ${{ inputs.node-version }}
+                  cache: npm
 
             - name: Install Node.js dependencies
               run: |
@@ -201,7 +181,7 @@ jobs:
             - name: Run Playwright tests
               run: npx playwright test
               env:
-                  WP_BASE_URL: ${{ inputs.use-ddev && steps.ddev-url.outputs.url || 'http://localhost:8080' }}
+                  WP_BASE_URL: http://localhost:8080
                   WP_ADMIN_USER: admin
                   WP_ADMIN_PASSWORD: admin
 
@@ -209,6 +189,57 @@ jobs:
               if: always()
               with:
                   name: playwright-report-wp${{ matrix.wp }}${{ matrix.multisite && '-multisite' || '' }}
+                  path: |
+                      playwright-report/
+                      test-results/
+                  retention-days: 7
+
+    e2e-ddev:
+        name: E2E (DDEV)
+        if: ${{ inputs.use-ddev }}
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+
+            - name: Set up DDEV
+              uses: ddev/github-action-setup-ddev@v1
+
+            - name: Start DDEV environment
+              run: ddev start && ddev orchestrate
+
+            - name: Detect DDEV site URL
+              id: ddev-url
+              run: |
+                  URL=$(ddev describe -j | jq -r '.raw.primary_url // .raw.httpurl')
+                  echo "url=${URL}" >> "$GITHUB_OUTPUT"
+
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: ${{ inputs.node-version }}
+                  cache: npm
+
+            - name: Install Node.js dependencies
+              run: |
+                  if [ -f package-lock.json ]; then
+                      npm ci
+                  else
+                      npm install
+                  fi
+
+            - name: Install Playwright browsers
+              run: npx playwright install --with-deps chromium
+
+            - name: Run Playwright tests
+              run: npx playwright test
+              env:
+                  WP_BASE_URL: ${{ steps.ddev-url.outputs.url }}
+                  WP_ADMIN_USER: admin
+                  WP_ADMIN_PASSWORD: admin
+
+            - uses: actions/upload-artifact@v4
+              if: always()
+              with:
+                  name: playwright-report-ddev
                   path: |
                       playwright-report/
                       test-results/

--- a/.github/workflows/reusable-wp-e2e.yml
+++ b/.github/workflows/reusable-wp-e2e.yml
@@ -28,6 +28,11 @@ on:
                 required: false
                 type: string
                 default: 'plugin'
+            use-ddev:
+                description: 'Use DDEV for WordPress setup instead of PHP built-in server'
+                required: false
+                type: boolean
+                default: false
 
 jobs:
     matrix-prep:
@@ -69,31 +74,34 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
+            # ── DDEV path ──
+            - name: Set up DDEV
+              if: inputs.use-ddev
+              uses: ddev/github-action-setup-ddev@v1
+
+            - name: Start DDEV environment
+              if: inputs.use-ddev
+              run: ddev start && ddev orchestrate
+
+            - name: Detect DDEV site URL
+              if: inputs.use-ddev
+              id: ddev-url
+              run: echo "url=$(ddev describe -j | jq -r '.raw.primary_url')" >> "$GITHUB_OUTPUT"
+
+            # ── Standard path ──
             - uses: shivammathur/setup-php@v2
+              if: ${{ !inputs.use-ddev }}
               with:
                   php-version: ${{ inputs.php-version }}
                   extensions: mysqli, intl, mbstring
                   coverage: none
                   tools: wp-cli
 
-            - uses: actions/setup-node@v4
-              with:
-                  node-version: ${{ inputs.node-version }}
-
             - run: composer install --no-interaction --prefer-dist
-
-            - name: Install Node.js dependencies
-              run: |
-                  if [ -f package-lock.json ]; then
-                      npm ci
-                  else
-                      npm install
-                  fi
-
-            - name: Install Playwright browsers
-              run: npx playwright install --with-deps chromium
+              if: ${{ !inputs.use-ddev }}
 
             - name: Resolve WP version
+              if: ${{ !inputs.use-ddev }}
               id: wp-version
               run: |
                   WP_INPUT="${{ matrix.wp }}"
@@ -106,6 +114,7 @@ jobs:
                   fi
 
             - name: Set up WordPress
+              if: ${{ !inputs.use-ddev }}
               run: |
                   WP_VERSION="${{ steps.wp-version.outputs.version }}"
 
@@ -141,6 +150,7 @@ jobs:
                   fi
 
             - name: Activate project
+              if: ${{ !inputs.use-ddev }}
               run: |
                   PROJECT_NAME=$(basename "${{ github.workspace }}")
                   MODE="${{ inputs.project-mode }}"
@@ -161,19 +171,37 @@ jobs:
                   fi
 
             - name: Start PHP server
+              if: ${{ !inputs.use-ddev }}
               run: php -S 0.0.0.0:8080 -t /tmp/wordpress/ &
 
             - name: Wait for server
+              if: ${{ !inputs.use-ddev }}
               run: |
                   for i in $(seq 1 10); do
                       curl -s http://localhost:8080/ > /dev/null && break
                       sleep 1
                   done
 
+            # ── Shared steps ──
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: ${{ inputs.node-version }}
+
+            - name: Install Node.js dependencies
+              run: |
+                  if [ -f package-lock.json ]; then
+                      npm ci
+                  else
+                      npm install
+                  fi
+
+            - name: Install Playwright browsers
+              run: npx playwright install --with-deps chromium
+
             - name: Run Playwright tests
               run: npx playwright test
               env:
-                  WP_BASE_URL: http://localhost:8080
+                  WP_BASE_URL: ${{ inputs.use-ddev && steps.ddev-url.outputs.url || 'http://localhost:8080' }}
                   WP_ADMIN_USER: admin
                   WP_ADMIN_PASSWORD: admin
 

--- a/.github/workflows/reusable-wp-integration.yml
+++ b/.github/workflows/reusable-wp-integration.yml
@@ -1,4 +1,4 @@
-name: Reusable WP Integration
+name: WP Integration
 
 on:
     workflow_call:
@@ -9,7 +9,7 @@ on:
                 type: string
                 default: '["8.3", "8.4"]'
             wp-versions:
-                description: 'JSON array of WP versions (e.g. "latest", "6.7", "6.6", "beta")'
+                description: 'JSON array of WP versions: strings or {version, name} objects'
                 required: false
                 type: string
                 default: '["latest"]'
@@ -54,7 +54,7 @@ jobs:
                   esac
 
     integration:
-        name: PHP ${{ matrix.php }} / WP ${{ matrix.wp }}${{ matrix.multisite && ' / multisite' || '' }}
+        name: PHP ${{ matrix.php }} / WP ${{ matrix.wp.name || matrix.wp }}${{ matrix.multisite && ' / multisite' || '' }}
         needs: matrix-prep
         runs-on: ubuntu-latest
         strategy:
@@ -96,7 +96,7 @@ jobs:
             - name: Resolve WP version
               id: wp-version
               run: |
-                  WP_INPUT="${{ matrix.wp }}"
+                  WP_INPUT="${{ matrix.wp.version || matrix.wp }}"
 
                   if [ "$WP_INPUT" = "latest" ]; then
                       WP_VERSION=$(curl -s https://api.wordpress.org/core/version-check/1.7/ | jq -r '.offers[0].version')

--- a/.github/workflows/reusable-wp-theme-ci.yml
+++ b/.github/workflows/reusable-wp-theme-ci.yml
@@ -60,6 +60,7 @@ jobs:
             - uses: actions/setup-node@v4
               with:
                   node-version: ${{ inputs.node-version }}
+                  cache: npm
 
             - name: Install dependencies
               run: |
@@ -69,7 +70,7 @@ jobs:
                       npm install
                   fi
 
-            - run: npm run ${{ inputs.eslint-command }}
+            - run: npm run "${{ inputs.eslint-command }}"
 
     stylelint:
         name: Stylelint
@@ -81,6 +82,7 @@ jobs:
             - uses: actions/setup-node@v4
               with:
                   node-version: ${{ inputs.node-version }}
+                  cache: npm
 
             - name: Install dependencies
               run: |
@@ -90,7 +92,7 @@ jobs:
                       npm install
                   fi
 
-            - run: npm run ${{ inputs.stylelint-command }}
+            - run: npm run "${{ inputs.stylelint-command }}"
 
     version-check:
         name: Version consistency
@@ -114,7 +116,7 @@ jobs:
 
             - name: Generate and verify version file
               run: |
-                  composer ${{ inputs.version-command }}
+                  composer "${{ inputs.version-command }}"
                   if ! git diff --exit-code -- "${{ inputs.version-file }}"; then
                       echo "::error::${{ inputs.version-file }} is out of date. Run 'composer ${{ inputs.version-command }}' and commit the result."
                       exit 1

--- a/.github/workflows/reusable-wp-theme-ci.yml
+++ b/.github/workflows/reusable-wp-theme-ci.yml
@@ -1,0 +1,121 @@
+name: WP Theme CI
+
+on:
+    workflow_call:
+        inputs:
+            node-version:
+                description: 'Node.js version'
+                required: false
+                type: string
+                default: '22'
+            php-version:
+                description: 'PHP version for version check'
+                required: false
+                type: string
+                default: '8.4'
+            run-eslint:
+                description: 'Run ESLint via npm'
+                required: false
+                type: boolean
+                default: true
+            eslint-command:
+                description: 'npm script for ESLint'
+                required: false
+                type: string
+                default: 'lint:js'
+            run-stylelint:
+                description: 'Run Stylelint via npm'
+                required: false
+                type: boolean
+                default: true
+            stylelint-command:
+                description: 'npm script for Stylelint'
+                required: false
+                type: string
+                default: 'lint:css'
+            run-version-check:
+                description: 'Verify generated version.php is up to date'
+                required: false
+                type: boolean
+                default: false
+            version-command:
+                description: 'Composer script to generate version file'
+                required: false
+                type: string
+                default: 'generate-version'
+            version-file:
+                description: 'Path to the generated version file'
+                required: false
+                type: string
+                default: 'version.php'
+
+jobs:
+    eslint:
+        name: ESLint
+        if: inputs.run-eslint
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: ${{ inputs.node-version }}
+
+            - name: Install dependencies
+              run: |
+                  if [ -f package-lock.json ]; then
+                      npm ci
+                  else
+                      npm install
+                  fi
+
+            - run: npm run ${{ inputs.eslint-command }}
+
+    stylelint:
+        name: Stylelint
+        if: inputs.run-stylelint
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: ${{ inputs.node-version }}
+
+            - name: Install dependencies
+              run: |
+                  if [ -f package-lock.json ]; then
+                      npm ci
+                  else
+                      npm install
+                  fi
+
+            - run: npm run ${{ inputs.stylelint-command }}
+
+    version-check:
+        name: Version consistency
+        if: inputs.run-version-check
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+
+            - uses: shivammathur/setup-php@v2
+              with:
+                  php-version: ${{ inputs.php-version }}
+                  coverage: none
+
+            - uses: actions/cache@v4
+              with:
+                  path: vendor
+                  key: composer-${{ inputs.php-version }}-${{ hashFiles('composer.lock') }}
+                  restore-keys: composer-${{ inputs.php-version }}-
+
+            - run: composer install --no-interaction --prefer-dist
+
+            - name: Generate and verify version file
+              run: |
+                  composer ${{ inputs.version-command }}
+                  if ! git diff --exit-code -- "${{ inputs.version-file }}"; then
+                      echo "::error::${{ inputs.version-file }} is out of date. Run 'composer ${{ inputs.version-command }}' and commit the result."
+                      exit 1
+                  fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - Unreleased
+
+### Added
+
+- WP theme CI workflow with ESLint, Stylelint, and version consistency check (#2)
+- DDEV-based E2E testing via `use-ddev` input in WP E2E workflow (#6)
+- Labeled WP versions support in integration matrix via `{version, name}` objects (#3)
+
+### Changed
+
+- Rename integration workflow from "Reusable WP Integration" to "WP Integration"
+
 ## [0.1.1] - 2026-03-19
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.2.0] - Unreleased
+## [0.2.0] - 2026-03-21
 
 ### Added
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,7 @@ All reusable workflows live in `.github/workflows/` with the `reusable-` prefix.
 | `reusable-conventional-commits.yml` | Commit message format validation |
 | `reusable-prerelease.yml` | Manual prerelease from release branches |
 | `reusable-stale.yml` | Auto-close stale issues/PRs |
+| `reusable-wp-theme-ci.yml` | WP theme CI (ESLint, Stylelint, version check) |
 | `reusable-wporg-deploy.yml` | Deploy plugin/theme to WordPress.org SVN |
 
 ### Self-referencing CI


### PR DESCRIPTION
## Summary

- Add `reusable-wp-theme-ci.yml` with ESLint, Stylelint, and version consistency check jobs (closes #2)
- Support `{version, name}` objects in `wp-versions` input for labeled integration matrix jobs (closes #3)
- Add `use-ddev` input to `reusable-wp-e2e.yml` for DDEV-based E2E testing (closes #6)
- Shorten integration workflow name to "WP Integration"

## Test plan

- [x] Verify integration workflow still works with plain string `wp-versions`
- [x] Test integration workflow with `{version, name}` objects and check job names
- [x] Test E2E workflow with `use-ddev: false` (default, existing behavior)
- [x] Test E2E workflow with `use-ddev: true` from a DDEV-enabled repo
- [x] Test theme CI workflow with ESLint/Stylelint enabled
- [x] Test theme CI version check with `run-version-check: true`

Validated via actionlint + static expression analysis (no caller workflows in this repo for live testing).