### PR TITLE
fix(e2e): hide skipped matrix jobs in DDEV mode

### DIFF
--- a/.github/workflows/reusable-wp-e2e.yml
+++ b/.github/workflows/reusable-wp-e2e.yml
@@ -37,28 +37,38 @@ on:
 jobs:
     matrix-prep:
         name: Prepare matrix
-        if: ${{ !inputs.use-ddev }}
         runs-on: ubuntu-latest
         outputs:
+            wp-versions: ${{ steps.wp.outputs.matrix }}
             multisite: ${{ steps.multisite.outputs.matrix }}
         steps:
+            - id: wp
+              run: |
+                  if [ "${{ inputs.use-ddev }}" = "true" ]; then
+                      echo "matrix=[]" >> "$GITHUB_OUTPUT"
+                  else
+                      echo "matrix=${{ inputs.wp-versions }}" >> "$GITHUB_OUTPUT"
+                  fi
             - id: multisite
               run: |
-                  case "${{ inputs.multisite }}" in
-                      both) echo "matrix=[false, true]" >> "$GITHUB_OUTPUT" ;;
-                      only) echo "matrix=[true]" >> "$GITHUB_OUTPUT" ;;
-                      *)    echo "matrix=[false]" >> "$GITHUB_OUTPUT" ;;
-                  esac
+                  if [ "${{ inputs.use-ddev }}" = "true" ]; then
+                      echo "matrix=[false]" >> "$GITHUB_OUTPUT"
+                  else
+                      case "${{ inputs.multisite }}" in
+                          both) echo "matrix=[false, true]" >> "$GITHUB_OUTPUT" ;;
+                          only) echo "matrix=[true]" >> "$GITHUB_OUTPUT" ;;
+                          *)    echo "matrix=[false]" >> "$GITHUB_OUTPUT" ;;
+                      esac
+                  fi
 
     e2e:
         name: WP ${{ matrix.wp }}${{ matrix.multisite && ' / multisite' || '' }}
-        if: ${{ !inputs.use-ddev }}
         needs: matrix-prep
         runs-on: ubuntu-latest
         strategy:
             fail-fast: false
             matrix:
-                wp: ${{ fromJson(inputs.wp-versions) }}
+                wp: ${{ fromJson(needs.matrix-prep.outputs.wp-versions) }}
                 multisite: ${{ fromJson(needs.matrix-prep.outputs.multisite) }}
         services:
             mysql:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2026-03-21
+
+### Fixed
+
+- E2E workflow: skipped matrix jobs no longer show unresolved expressions in DDEV mode (#9)
+
 ## [0.2.0] - 2026-03-21
 
 ### Added


### PR DESCRIPTION
## Summary

- Use empty matrix (`[]`) instead of job-level `if:` guard for the `e2e` job when `use-ddev` is true
- When the matrix is empty, GitHub generates zero job instances — nothing shows in the UI
- Previously, skipped jobs showed with unresolved `${{ matrix.wp }}` expressions

Closes #9