### PR TITLE
feat(e2e): replace PHP server and DDEV with wp-env

### DIFF
--- a/.github/workflows/reusable-wp-e2e.yml
+++ b/.github/workflows/reusable-wp-e2e.yml
@@ -113,16 +113,19 @@ jobs:
                       $dir = ABSPATH . "wp-content/mu-plugins";
                       if (!is_dir($dir)) { mkdir($dir, 0755, true); }
                       file_put_contents($dir . "/mailpit-smtp.php",
-                          "<?php\nadd_action(\"phpmailer_init\", function(\$phpmailer) {\n"
+                          "<?php\n"
+                          . "add_filter(\"wp_mail_from\", function(\$email) {\n"
+                          . "    if (strpos(\$email, \"@localhost\") !== false) {\n"
+                          . "        return \"wordpress@example.tld\";\n"
+                          . "    }\n"
+                          . "    return \$email;\n"
+                          . "});\n"
+                          . "add_action(\"phpmailer_init\", function(\$phpmailer) {\n"
                           . "    \$phpmailer->isSMTP();\n"
                           . "    \$phpmailer->Host = \"mailpit\";\n"
                           . "    \$phpmailer->Port = 1025;\n"
                           . "    \$phpmailer->SMTPAutoTLS = false;\n"
                           . "    \$phpmailer->SMTPAuth = false;\n"
-                          . "    if (strpos(\$phpmailer->From, \"localhost\") !== false) {\n"
-                          . "        \$phpmailer->From = \"wordpress@example.tld\";\n"
-                          . "        \$phpmailer->FromName = \"WordPress\";\n"
-                          . "    }\n"
                           . "});\n"
                       );
                   '

--- a/.github/workflows/reusable-wp-e2e.yml
+++ b/.github/workflows/reusable-wp-e2e.yml
@@ -82,6 +82,13 @@ jobs:
             - name: Install wp-env
               run: npm install -g @wordpress/env
 
+            - name: Validate wp-env configuration
+              run: |
+                  if [ ! -f .wp-env.json ]; then
+                      echo "::error::Missing .wp-env.json in repository root. See https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/"
+                      exit 1
+                  fi
+
             - name: Configure wp-env override
               if: matrix.wp.core != 'null'
               run: |
@@ -100,9 +107,13 @@ jobs:
                   docker run -d --name mailpit \
                       -p 1025:1025 \
                       -p 8025:8025 \
-                      axllent/mailpit
+                      axllent/mailpit:v1
 
-                  WP_CONTAINER=$(docker ps -qf "name=wordpress" --no-trunc | head -1)
+                  WP_CONTAINER=$(docker ps -q --filter "label=com.docker.compose.service=wordpress" --no-trunc | head -1)
+                  if [ -z "$WP_CONTAINER" ]; then
+                      echo "::error::Could not find wp-env WordPress container"
+                      exit 1
+                  fi
                   WP_NETWORK=$(docker inspect -f '{{range $k, $_ := .NetworkSettings.Networks}}{{$k}} {{end}}' "$WP_CONTAINER" | awk '{print $1}')
                   docker network connect "$WP_NETWORK" mailpit
 

--- a/.github/workflows/reusable-wp-e2e.yml
+++ b/.github/workflows/reusable-wp-e2e.yml
@@ -127,14 +127,21 @@ jobs:
               if: inputs.mailpit
               run: |
                   npx wp-env run cli wp eval '
-                      $f = fsockopen("mailpit", 1025, $errno, $errstr, 5);
-                      if (!$f) { echo "SMTP unreachable: $errstr ($errno)\n"; exit(1); }
-                      fclose($f);
-                      echo "SMTP OK";
-                  '
-                  npx wp-env run cli wp eval '
+                      echo "mu-plugins dir: " . WPMU_PLUGIN_DIR . "\n";
+                      echo "mu-plugin exists: " . (file_exists(WPMU_PLUGIN_DIR . "/mailpit-smtp.php") ? "yes" : "no") . "\n";
+                      echo "hook registered: " . (has_action("phpmailer_init") ? "yes" : "no") . "\n";
+
+                      add_action("wp_mail_failed", function($error) {
+                          echo "wp_mail_failed: " . $error->get_error_message() . "\n";
+                      });
+
+                      global $phpmailer;
                       $result = wp_mail("test@example.tld", "Smoke test", "Mailpit connectivity check");
-                      echo $result ? "wp_mail OK" : "wp_mail FAILED";
+                      echo $result ? "wp_mail: OK" : "wp_mail: FAILED";
+                      if (isset($phpmailer) && $phpmailer->ErrorInfo) {
+                          echo " — " . $phpmailer->ErrorInfo;
+                      }
+                      echo "\n";
                       if (!$result) { exit(1); }
                   '
                   curl -sf http://localhost:8025/api/v1/messages | jq '.total'

--- a/.github/workflows/reusable-wp-e2e.yml
+++ b/.github/workflows/reusable-wp-e2e.yml
@@ -109,7 +109,7 @@ jobs:
                       -p 8025:8025 \
                       axllent/mailpit:v1
 
-                  WP_CONTAINER=$(docker ps -q --filter "label=com.docker.compose.service=wordpress" --no-trunc | head -1)
+                  WP_CONTAINER=$(docker ps --format '{{.ID}}' --filter "name=wordpress" --no-trunc | head -1)
                   if [ -z "$WP_CONTAINER" ]; then
                       echo "::error::Could not find wp-env WordPress container"
                       exit 1

--- a/.github/workflows/reusable-wp-e2e.yml
+++ b/.github/workflows/reusable-wp-e2e.yml
@@ -123,6 +123,22 @@ jobs:
                       );
                   '
 
+            - name: Verify Mailpit connectivity
+              if: inputs.mailpit
+              run: |
+                  npx wp-env run cli wp eval '
+                      $f = fsockopen("mailpit", 1025, $errno, $errstr, 5);
+                      if (!$f) { echo "SMTP unreachable: $errstr ($errno)\n"; exit(1); }
+                      fclose($f);
+                      echo "SMTP OK";
+                  '
+                  npx wp-env run cli wp eval '
+                      $result = wp_mail("test@example.tld", "Smoke test", "Mailpit connectivity check");
+                      echo $result ? "wp_mail OK" : "wp_mail FAILED";
+                      if (!$result) { exit(1); }
+                  '
+                  curl -sf http://localhost:8025/api/v1/messages | jq '.total'
+
             - name: Install Playwright browsers
               run: npx playwright install --with-deps chromium
 

--- a/.github/workflows/reusable-wp-e2e.yml
+++ b/.github/workflows/reusable-wp-e2e.yml
@@ -119,9 +119,15 @@ jobs:
                           . "    \$phpmailer->Port = 1025;\n"
                           . "    \$phpmailer->SMTPAutoTLS = false;\n"
                           . "    \$phpmailer->SMTPAuth = false;\n"
+                          . "    if (strpos(\$phpmailer->From, \"localhost\") !== false) {\n"
+                          . "        \$phpmailer->From = \"wordpress@example.tld\";\n"
+                          . "        \$phpmailer->FromName = \"WordPress\";\n"
+                          . "    }\n"
                           . "});\n"
                       );
                   '
+                  npx wp-env run cli wp option update siteurl http://localhost:8888
+                  npx wp-env run cli wp option update home http://localhost:8888
 
             - name: Verify Mailpit connectivity
               if: inputs.mailpit

--- a/.github/workflows/reusable-wp-e2e.yml
+++ b/.github/workflows/reusable-wp-e2e.yml
@@ -18,6 +18,11 @@ on:
                 required: false
                 type: string
                 default: 'none'
+            mailpit:
+                description: 'Run Mailpit mail catcher (SMTP on :1025, UI on :8025)'
+                required: false
+                type: boolean
+                default: false
 
 jobs:
     matrix-prep:
@@ -89,6 +94,35 @@ jobs:
               if: matrix.multisite
               run: npx wp-env run cli wp core multisite-convert --title="Test Site"
 
+            - name: Start Mailpit
+              if: inputs.mailpit
+              run: |
+                  docker run -d --name mailpit \
+                      -p 1025:1025 \
+                      -p 8025:8025 \
+                      axllent/mailpit
+
+                  WP_CONTAINER=$(docker ps -qf "name=wordpress" --no-trunc | head -1)
+                  WP_NETWORK=$(docker inspect -f '{{range $k, $_ := .NetworkSettings.Networks}}{{$k}} {{end}}' "$WP_CONTAINER" | awk '{print $1}')
+                  docker network connect "$WP_NETWORK" mailpit
+
+            - name: Configure WordPress SMTP for Mailpit
+              if: inputs.mailpit
+              run: |
+                  npx wp-env run cli wp eval '
+                      $dir = ABSPATH . "wp-content/mu-plugins";
+                      if (!is_dir($dir)) { mkdir($dir, 0755, true); }
+                      file_put_contents($dir . "/mailpit-smtp.php",
+                          "<?php\nadd_action(\"phpmailer_init\", function(\$phpmailer) {\n"
+                          . "    \$phpmailer->isSMTP();\n"
+                          . "    \$phpmailer->Host = \"mailpit\";\n"
+                          . "    \$phpmailer->Port = 1025;\n"
+                          . "    \$phpmailer->SMTPAutoTLS = false;\n"
+                          . "    \$phpmailer->SMTPAuth = false;\n"
+                          . "});\n"
+                      );
+                  '
+
             - name: Install Playwright browsers
               run: npx playwright install --with-deps chromium
 
@@ -98,6 +132,7 @@ jobs:
                   WP_BASE_URL: http://localhost:8888
                   WP_ADMIN_USER: admin
                   WP_ADMIN_PASSWORD: password
+                  MAILPIT_API_URL: ${{ inputs.mailpit && 'http://localhost:8025' || '' }}
 
             - uses: actions/upload-artifact@v4
               if: always()

--- a/.github/workflows/reusable-wp-e2e.yml
+++ b/.github/workflows/reusable-wp-e2e.yml
@@ -107,7 +107,7 @@ jobs:
                   docker run -d --name mailpit \
                       -p 1025:1025 \
                       -p 8025:8025 \
-                      axllent/mailpit:v1
+                      axllent/mailpit:latest
 
                   WP_CONTAINER=$(docker ps --format '{{.ID}}' --filter "name=wordpress" --no-trunc | head -1)
                   if [ -z "$WP_CONTAINER" ]; then

--- a/.github/workflows/reusable-wp-e2e.yml
+++ b/.github/workflows/reusable-wp-e2e.yml
@@ -3,45 +3,35 @@ name: Reusable WP E2E
 on:
     workflow_call:
         inputs:
-            php-version:
-                description: 'PHP version'
-                required: false
-                type: string
-                default: '8.4'
             node-version:
                 description: 'Node.js version'
                 required: false
                 type: string
                 default: '22'
             wp-versions:
-                description: 'JSON array of WP versions (e.g. "latest", "6.7"). Ignored when use-ddev is true.'
+                description: 'JSON array of WP versions (e.g. "latest", "6.7")'
                 required: false
                 type: string
                 default: '["latest"]'
             multisite:
-                description: 'Multisite mode: "none", "both", or "only". Ignored when use-ddev is true.'
+                description: 'Multisite mode: "none", "both", or "only"'
                 required: false
                 type: string
                 default: 'none'
-            project-mode:
-                description: 'Project mode: "plugin" or "theme"'
-                required: false
-                type: string
-                default: 'plugin'
-            use-ddev:
-                description: 'Use DDEV for WordPress setup instead of PHP built-in server'
-                required: false
-                type: boolean
-                default: false
 
 jobs:
     matrix-prep:
         name: Prepare matrix
-        if: ${{ !inputs.use-ddev }}
         runs-on: ubuntu-latest
         outputs:
+            wp-versions: ${{ steps.wp-versions.outputs.matrix }}
             multisite: ${{ steps.multisite.outputs.matrix }}
         steps:
+            - id: wp-versions
+              run: |
+                  MATRIX=$(echo '${{ inputs.wp-versions }}' | jq -c '[.[] | if . == "latest" then {"input": "latest", "core": "null"} else {"input": ., "core": ("WordPress/WordPress#" + .)} end]')
+                  echo "matrix=${MATRIX}" >> "$GITHUB_OUTPUT"
+
             - id: multisite
               run: |
                   case "${{ inputs.multisite }}" in
@@ -51,116 +41,25 @@ jobs:
                   esac
 
     e2e:
-        name: WP ${{ matrix.wp }}${{ matrix.multisite && ' / multisite' || '' }}
-        if: ${{ !inputs.use-ddev }}
+        name: WP ${{ matrix.wp.input }}${{ matrix.multisite && ' / multisite' || '' }}
         needs: matrix-prep
         runs-on: ubuntu-latest
         strategy:
             fail-fast: false
             matrix:
-                wp: ${{ fromJson(inputs.wp-versions) }}
+                wp: ${{ fromJson(needs.matrix-prep.outputs.wp-versions) }}
                 multisite: ${{ fromJson(needs.matrix-prep.outputs.multisite) }}
-        services:
-            mysql:
-                image: mysql:8.0
-                env:
-                    MYSQL_ROOT_PASSWORD: root
-                    MYSQL_DATABASE: wordpress
-                ports:
-                    - 3306:3306
-                options: >-
-                    --health-cmd="mysqladmin ping"
-                    --health-interval=10s
-                    --health-timeout=5s
-                    --health-retries=5
         steps:
             - uses: actions/checkout@v4
 
             - uses: shivammathur/setup-php@v2
               with:
-                  php-version: ${{ inputs.php-version }}
-                  extensions: mysqli, intl, mbstring
+                  php-version: '8.4'
                   coverage: none
-                  tools: wp-cli
 
-            - run: composer install --no-interaction --prefer-dist
-
-            - name: Resolve WP version
-              id: wp-version
-              run: |
-                  WP_INPUT="${{ matrix.wp }}"
-
-                  if [ "$WP_INPUT" = "latest" ]; then
-                      WP_VERSION=$(curl -s https://api.wordpress.org/core/version-check/1.7/ | jq -r '.offers[0].version')
-                      echo "version=${WP_VERSION}" >> "$GITHUB_OUTPUT"
-                  else
-                      echo "version=${WP_INPUT}" >> "$GITHUB_OUTPUT"
-                  fi
-
-            - name: Set up WordPress
-              run: |
-                  WP_VERSION="${{ steps.wp-version.outputs.version }}"
-
-                  mkdir -p /tmp/wordpress
-                  curl -sL "https://wordpress.org/wordpress-${WP_VERSION}.tar.gz" | tar xz --strip-components=1 -C /tmp/wordpress
-
-                  wp config create \
-                      --dbname=wordpress \
-                      --dbuser=root \
-                      --dbpass=root \
-                      --dbhost=127.0.0.1 \
-                      --path=/tmp/wordpress
-
-                  MULTISITE=${{ matrix.multisite }}
-                  if [ "$MULTISITE" = "true" ]; then
-                      wp core multisite-install \
-                          --url=http://localhost:8080 \
-                          --title="Test Site" \
-                          --admin_user=admin \
-                          --admin_password=admin \
-                          --admin_email=admin@example.com \
-                          --skip-email \
-                          --path=/tmp/wordpress
-                  else
-                      wp core install \
-                          --url=http://localhost:8080 \
-                          --title="Test Site" \
-                          --admin_user=admin \
-                          --admin_password=admin \
-                          --admin_email=admin@example.com \
-                          --skip-email \
-                          --path=/tmp/wordpress
-                  fi
-
-            - name: Activate project
-              run: |
-                  PROJECT_NAME=$(basename "${{ github.workspace }}")
-                  MODE="${{ inputs.project-mode }}"
-
-                  if [ "$MODE" = "plugin" ]; then
-                      ln -s "${{ github.workspace }}" "/tmp/wordpress/wp-content/plugins/${PROJECT_NAME}"
-                      NETWORK_FLAG=""
-                      if [ "${{ matrix.multisite }}" = "true" ]; then
-                          NETWORK_FLAG="--network"
-                      fi
-                      wp plugin activate "${PROJECT_NAME}" ${NETWORK_FLAG} --path=/tmp/wordpress || true
-                  else
-                      ln -s "${{ github.workspace }}" "/tmp/wordpress/wp-content/themes/${PROJECT_NAME}"
-                      if [ "${{ matrix.multisite }}" = "true" ]; then
-                          wp theme enable "${PROJECT_NAME}" --network --path=/tmp/wordpress || true
-                      fi
-                      wp theme activate "${PROJECT_NAME}" --path=/tmp/wordpress || true
-                  fi
-
-            - name: Start PHP server
-              run: php -S 0.0.0.0:8080 -t /tmp/wordpress/ &
-
-            - name: Wait for server
-              run: |
-                  for i in $(seq 1 10); do
-                      curl -s http://localhost:8080/ > /dev/null && break
-                      sleep 1
-                  done
+            - name: Install Composer dependencies
+              if: hashFiles('composer.json') != ''
+              run: composer install --no-interaction --prefer-dist
 
             - uses: actions/setup-node@v4
               with:
@@ -175,56 +74,19 @@ jobs:
                       npm install
                   fi
 
-            - name: Install Playwright browsers
-              run: npx playwright install --with-deps chromium
+            - name: Install wp-env
+              run: npm install -g @wordpress/env
 
-            - name: Run Playwright tests
-              run: npx playwright test
-              env:
-                  WP_BASE_URL: http://localhost:8080
-                  WP_ADMIN_USER: admin
-                  WP_ADMIN_PASSWORD: admin
+            - name: Configure wp-env override
+              if: matrix.wp.core != 'null'
+              run: echo '{ "core": "${{ matrix.wp.core }}" }' > .wp-env.override.json
 
-            - uses: actions/upload-artifact@v4
-              if: always()
-              with:
-                  name: playwright-report-wp${{ matrix.wp }}${{ matrix.multisite && '-multisite' || '' }}
-                  path: |
-                      playwright-report/
-                      test-results/
-                  retention-days: 7
+            - name: Start wp-env
+              run: npx wp-env start
 
-    e2e-ddev:
-        name: E2E (DDEV)
-        if: ${{ inputs.use-ddev }}
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4
-
-            - name: Set up DDEV
-              uses: ddev/github-action-setup-ddev@v1
-
-            - name: Start DDEV environment
-              run: ddev start && ddev orchestrate
-
-            - name: Detect DDEV site URL
-              id: ddev-url
-              run: |
-                  URL=$(ddev describe -j | jq -r '.raw.primary_url // .raw.httpurl')
-                  echo "url=${URL}" >> "$GITHUB_OUTPUT"
-
-            - uses: actions/setup-node@v4
-              with:
-                  node-version: ${{ inputs.node-version }}
-                  cache: npm
-
-            - name: Install Node.js dependencies
-              run: |
-                  if [ -f package-lock.json ]; then
-                      npm ci
-                  else
-                      npm install
-                  fi
+            - name: Convert to multisite
+              if: matrix.multisite
+              run: npx wp-env run cli wp core multisite-convert --title="Test Site"
 
             - name: Install Playwright browsers
               run: npx playwright install --with-deps chromium
@@ -232,14 +94,14 @@ jobs:
             - name: Run Playwright tests
               run: npx playwright test
               env:
-                  WP_BASE_URL: ${{ steps.ddev-url.outputs.url }}
+                  WP_BASE_URL: http://localhost:8888
                   WP_ADMIN_USER: admin
-                  WP_ADMIN_PASSWORD: admin
+                  WP_ADMIN_PASSWORD: password
 
             - uses: actions/upload-artifact@v4
               if: always()
               with:
-                  name: playwright-report-ddev
+                  name: playwright-report-wp${{ matrix.wp.input }}${{ matrix.multisite && '-multisite' || '' }}
                   path: |
                       playwright-report/
                       test-results/

--- a/.github/workflows/reusable-wp-e2e.yml
+++ b/.github/workflows/reusable-wp-e2e.yml
@@ -79,7 +79,8 @@ jobs:
 
             - name: Configure wp-env override
               if: matrix.wp.core != 'null'
-              run: echo '{ "core": "${{ matrix.wp.core }}" }' > .wp-env.override.json
+              run: |
+                  echo '{ "core": "${{ matrix.wp.core }}" }' > .wp-env.override.json
 
             - name: Start wp-env
               run: npx wp-env start

--- a/.github/workflows/reusable-wp-e2e.yml
+++ b/.github/workflows/reusable-wp-e2e.yml
@@ -129,31 +129,6 @@ jobs:
                           . "});\n"
                       );
                   '
-                  npx wp-env run cli wp option update siteurl http://localhost:8888
-                  npx wp-env run cli wp option update home http://localhost:8888
-
-            - name: Verify Mailpit connectivity
-              if: inputs.mailpit
-              run: |
-                  npx wp-env run cli wp eval '
-                      echo "mu-plugins dir: " . WPMU_PLUGIN_DIR . "\n";
-                      echo "mu-plugin exists: " . (file_exists(WPMU_PLUGIN_DIR . "/mailpit-smtp.php") ? "yes" : "no") . "\n";
-                      echo "hook registered: " . (has_action("phpmailer_init") ? "yes" : "no") . "\n";
-
-                      add_action("wp_mail_failed", function($error) {
-                          echo "wp_mail_failed: " . $error->get_error_message() . "\n";
-                      });
-
-                      global $phpmailer;
-                      $result = wp_mail("test@example.tld", "Smoke test", "Mailpit connectivity check");
-                      echo $result ? "wp_mail: OK" : "wp_mail: FAILED";
-                      if (isset($phpmailer) && $phpmailer->ErrorInfo) {
-                          echo " — " . $phpmailer->ErrorInfo;
-                      }
-                      echo "\n";
-                      if (!$result) { exit(1); }
-                  '
-                  curl -sf http://localhost:8025/api/v1/messages | jq '.total'
 
             - name: Install Playwright browsers
               run: npx playwright install --with-deps chromium

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.3.0] - 2026-04-06
 
+### Added
+
+- `reusable-wp-e2e.yml` — optional Mailpit mail catcher via `mailpit` input
+
 ### Changed
 
 - `reusable-wp-e2e.yml` — replaced PHP built-in server and DDEV with wp-env (#14)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2026-04-06
+
+### Changed
+
+- `reusable-wp-e2e.yml` — replaced PHP built-in server and DDEV with wp-env (#14)
+
+### Removed
+
+- `reusable-wp-e2e.yml` — removed `php-version`, `project-mode`, and `use-ddev` inputs
+
 ## [0.2.0] - 2026-03-21
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ All reusable workflows live in `.github/workflows/` with the `reusable-` prefix.
 |------|---------|
 | `reusable-ci.yml` | PHP CI (test matrix, PHPStan, PHPCS) |
 | `reusable-wp-integration.yml` | WP integration tests (real WP + MySQL matrix) |
-| `reusable-wp-e2e.yml` | WP E2E tests (Playwright + PHP built-in server) |
+| `reusable-wp-e2e.yml` | WP E2E tests (Playwright + wp-env) |
 | `reusable-release.yml` | CHANGELOG-driven release creation |
 | `reusable-pr-validation.yml` | CHANGELOG entry validation |
 | `reusable-conventional-commits.yml` | Commit message format validation |

--- a/README.md
+++ b/README.md
@@ -37,15 +37,16 @@ jobs:
 
 ### `reusable-wp-e2e.yml`
 
-WordPress E2E test pipeline with Playwright. Runs Chromium against a PHP built-in server serving WordPress.
+WordPress E2E test pipeline with Playwright. Runs Chromium against a wp-env Docker environment.
+
+Caller repos must include a `.wp-env.json` in their root (see
+[wp-env docs](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/)).
 
 | Input | Type | Default | Description |
 |-------|------|---------|-------------|
-| `php-version` | string | `"8.4"` | PHP version |
 | `node-version` | string | `"22"` | Node.js version |
 | `wp-versions` | string (JSON) | `["latest"]` | WP versions to test |
 | `multisite` | string | `"none"` | `"none"`, `"both"`, or `"only"` |
-| `project-mode` | string | `"plugin"` | `"plugin"` or `"theme"` |
 
 ```yaml
 jobs:

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Caller repos must include a `.wp-env.json` in their root (see
 | `node-version` | string | `"22"` | Node.js version |
 | `wp-versions` | string (JSON) | `["latest"]` | WP versions (`"latest"`, `"6.7"`, `"beta"`) |
 | `multisite` | string | `"none"` | `"none"`, `"both"`, or `"only"` |
+| `mailpit` | boolean | `false` | Run Mailpit mail catcher (SMTP `:1025`, API `:8025`) |
 
 Recommended `wp-versions` setup: test against `"latest"` and the minimum supported WP version (e.g. `'["latest", "6.4"]'`).
 

--- a/README.md
+++ b/README.md
@@ -50,12 +50,14 @@ Caller repos must include a `.wp-env.json` in their root (see
 | `wp-versions` | string (JSON) | `["latest"]` | WP versions (`"latest"`, `"6.7"`, `"beta"`) |
 | `multisite` | string | `"none"` | `"none"`, `"both"`, or `"only"` |
 
+Recommended `wp-versions` setup: test against `"latest"` and the minimum supported WP version (e.g. `'["latest", "6.4"]'`).
+
 ```yaml
 jobs:
   e2e:
     uses: apermo/reusable-workflows/.github/workflows/reusable-wp-e2e.yml@main
     with:
-      wp-versions: '["latest"]'
+      wp-versions: '["latest", "6.4"]'
 ```
 
 ### `reusable-ci.yml`

--- a/README.md
+++ b/README.md
@@ -39,13 +39,15 @@ jobs:
 
 WordPress E2E test pipeline with Playwright. Runs Chromium against a wp-env Docker environment.
 
+The environment is available at `http://localhost:8888` with the default WordPress credentials (`admin` / `password`).
+
 Caller repos must include a `.wp-env.json` in their root (see
 [wp-env docs](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/)).
 
 | Input | Type | Default | Description |
 |-------|------|---------|-------------|
 | `node-version` | string | `"22"` | Node.js version |
-| `wp-versions` | string (JSON) | `["latest"]` | WP versions to test |
+| `wp-versions` | string (JSON) | `["latest"]` | WP versions (`"latest"`, `"6.7"`, `"beta"`) |
 | `multisite` | string | `"none"` | `"none"`, `"both"`, or `"only"` |
 
 ```yaml

--- a/README.md
+++ b/README.md
@@ -42,12 +42,19 @@ WordPress E2E test pipeline with Playwright. Runs Chromium against a wp-env Dock
 The environment is available at `http://localhost:8888` with the default WordPress credentials (`admin` / `password`).
 
 Caller repos must include a `.wp-env.json` in their root (see
-[wp-env docs](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/)).
+[wp-env docs](https://developer.wordpress.org/block-editor/reference-guides/packages/packages-env/)). For example, to test the
+plugin in the current directory:
+
+```json
+{
+  "plugins": ["."]
+}
+```
 
 | Input | Type | Default | Description |
 |-------|------|---------|-------------|
 | `node-version` | string | `"22"` | Node.js version |
-| `wp-versions` | string (JSON) | `["latest"]` | WP versions (`"latest"`, `"6.7"`, `"beta"`) |
+| `wp-versions` | string (JSON) | `["latest"]` | WP versions (`"latest"`, `"6.7"`) |
 | `multisite` | string | `"none"` | `"none"`, `"both"`, or `"only"` |
 | `mailpit` | boolean | `false` | Run Mailpit mail catcher (SMTP `:1025`, API `:8025`) |
 


### PR DESCRIPTION
## Summary

- Replaces both the PHP built-in server path and the DDEV path with a single `@wordpress/env` (wp-env) approach
- Removes `php-version`, `project-mode`, and `use-ddev` inputs — wp-env handles PHP, DB, and project mounting via
  the caller's `.wp-env.json`
- Supports WP version × multisite matrix testing with Docker (MariaDB included)

Closes #14

## Breaking changes for consumers

| Aspect | Before | After |
|--------|--------|-------|
| Caller requirement | None | `.wp-env.json` in repo root |
| WP port | 8080 | 8888 |
| Admin password | `admin` | `password` |
| PHP version | `php-version` input | wp-env container default |
| Plugin/theme mode | `project-mode` input | `.wp-env.json` config |
| DDEV support | `use-ddev: true` | Removed |

## Test plan

- [x] Point a consumer repo at `@feature/wp-env-e2e` and verify wp-env starts
- [x] Verify matrix jobs (WP latest + pinned version × multisite) run correctly
- [x] Verify Playwright tests pass against wp-env at `localhost:8888`
- [x] Verify artifact upload works with new naming scheme