### PR TITLE
feat(e2e): add optional a11y testing support

### DIFF
--- a/.github/workflows/reusable-wp-e2e.yml
+++ b/.github/workflows/reusable-wp-e2e.yml
@@ -23,6 +23,11 @@ on:
                 required: false
                 type: boolean
                 default: false
+            a11y:
+                description: 'Install @axe-core/playwright for accessibility testing'
+                required: false
+                type: boolean
+                default: false
 
 jobs:
     matrix-prep:
@@ -78,6 +83,10 @@ jobs:
                   else
                       npm install
                   fi
+
+            - name: Install @axe-core/playwright
+              if: inputs.a11y
+              run: npm install --no-save @axe-core/playwright
 
             - name: Install wp-env
               run: npm install -g @wordpress/env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-04-08
+
+### Added
+
+- `reusable-wp-e2e.yml` — optional `@axe-core/playwright` install via `a11y` input (#16)
+
 ## [0.3.0] - 2026-04-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ plugin in the current directory:
 | `wp-versions` | string (JSON) | `["latest"]` | WP versions (`"latest"`, `"6.7"`) |
 | `multisite` | string | `"none"` | `"none"`, `"both"`, or `"only"` |
 | `mailpit` | boolean | `false` | Run Mailpit mail catcher (SMTP `:1025`, API `:8025`) |
+| `a11y` | boolean | `false` | Install `@axe-core/playwright` for accessibility testing |
 
 Recommended `wp-versions` setup: test against `"latest"` and the minimum supported WP version (e.g. `'["latest", "6.4"]'`).
 


### PR DESCRIPTION
## Summary

- Add `a11y` boolean input to `reusable-wp-e2e.yml` that installs `@axe-core/playwright` when enabled
- Update README.md with the new input in the e2e workflow table
- Add 0.4.0 CHANGELOG entry

Closes #16

## Test plan

- [ ] Verify workflow syntax is valid (CI should pass)
- [ ] Test with `a11y: true` — `@axe-core/playwright` should be installed after `npm ci`
- [ ] Test with `a11y: false` (default) — install step should be skipped