### PR TITLE
feat: add Lighthouse CI workflow

### DIFF
--- a/.github/workflows/reusable-lhci.yml
+++ b/.github/workflows/reusable-lhci.yml
@@ -1,0 +1,142 @@
+name: Reusable Lighthouse CI
+
+on:
+    workflow_call:
+        inputs:
+            urls:
+                description: 'JSON array of URLs to audit (e.g. ["http://localhost:8888"])'
+                required: false
+                type: string
+                default: '["http://localhost:8888"]'
+            node-version:
+                description: 'Node.js version'
+                required: false
+                type: string
+                default: '22'
+            runs:
+                description: 'Number of Lighthouse runs per URL (median is used)'
+                required: false
+                type: number
+                default: 3
+            setup-wp-env:
+                description: 'Start wp-env before running audits'
+                required: false
+                type: boolean
+                default: false
+            a11y-threshold:
+                description: 'Minimum accessibility score (0-100, 0 to skip)'
+                required: false
+                type: number
+                default: 90
+            performance-threshold:
+                description: 'Minimum performance score (0-100, 0 to skip)'
+                required: false
+                type: number
+                default: 0
+            seo-threshold:
+                description: 'Minimum SEO score (0-100, 0 to skip)'
+                required: false
+                type: number
+                default: 0
+            best-practices-threshold:
+                description: 'Minimum best practices score (0-100, 0 to skip)'
+                required: false
+                type: number
+                default: 0
+            config-path:
+                description: 'Path to lighthouserc in the consuming repo (overrides threshold inputs)'
+                required: false
+                type: string
+                default: ''
+
+jobs:
+    lighthouse:
+        name: Lighthouse CI
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: ${{ inputs.node-version }}
+
+            - name: Install Node.js dependencies
+              if: inputs.setup-wp-env
+              run: |
+                  if [ -f package-lock.json ]; then
+                      npm ci
+                  else
+                      npm install
+                  fi
+
+            - name: Install wp-env
+              if: inputs.setup-wp-env
+              run: npm install -g @wordpress/env
+
+            - name: Validate wp-env configuration
+              if: inputs.setup-wp-env
+              run: |
+                  if [ ! -f .wp-env.json ]; then
+                      echo "::error::Missing .wp-env.json in repository root"
+                      exit 1
+                  fi
+
+            - name: Start wp-env
+              if: inputs.setup-wp-env
+              run: npx wp-env start
+
+            - name: Install LHCI CLI
+              run: npm install -g @lhci/cli
+
+            - name: Generate lighthouserc
+              if: inputs.config-path == ''
+              run: |
+                  echo '${{ inputs.urls }}' | jq \
+                      --argjson runs "${{ inputs.runs }}" \
+                      --argjson a11y "${{ inputs.a11y-threshold }}" \
+                      --argjson perf "${{ inputs.performance-threshold }}" \
+                      --argjson seo "${{ inputs.seo-threshold }}" \
+                      --argjson bp "${{ inputs.best-practices-threshold }}" \
+                      '{
+                          ci: {
+                              collect: {
+                                  url: .,
+                                  numberOfRuns: $runs,
+                                  settings: {
+                                      chromeFlags: "--no-sandbox"
+                                  }
+                              },
+                              assert: {
+                                  assertions: (
+                                      {}
+                                      | if $a11y > 0 then . + {"categories:accessibility": ["error", {"minScore": ($a11y / 100)}]} else . end
+                                      | if $perf > 0 then . + {"categories:performance": ["error", {"minScore": ($perf / 100)}]} else . end
+                                      | if $seo > 0 then . + {"categories:seo": ["error", {"minScore": ($seo / 100)}]} else . end
+                                      | if $bp > 0 then . + {"categories:best-practices": ["error", {"minScore": ($bp / 100)}]} else . end
+                                  )
+                              },
+                              upload: {
+                                  target: "filesystem",
+                                  outputDir: ".lighthouseci"
+                              }
+                          }
+                      }' > .lighthouserc.json
+
+                  echo "::group::Generated .lighthouserc.json"
+                  cat .lighthouserc.json
+                  echo "::endgroup::"
+
+            - name: Run Lighthouse CI (generated config)
+              if: inputs.config-path == ''
+              run: lhci autorun
+
+            - name: Run Lighthouse CI (custom config)
+              if: inputs.config-path != ''
+              run: lhci autorun --config="${{ inputs.config-path }}"
+
+            - uses: actions/upload-artifact@v4
+              if: always()
+              with:
+                  name: lighthouse-report
+                  path: .lighthouseci/
+                  retention-days: 7

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-04-08
+
+### Added
+
+- `reusable-lhci.yml` — Lighthouse CI workflow with configurable score thresholds (#17)
+
 ## [0.3.0] - 2026-04-06
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,7 @@ All reusable workflows live in `.github/workflows/` with the `reusable-` prefix.
 | `reusable-ci.yml` | PHP CI (test matrix, PHPStan, PHPCS) |
 | `reusable-wp-integration.yml` | WP integration tests (real WP + MySQL matrix) |
 | `reusable-wp-e2e.yml` | WP E2E tests (Playwright + wp-env) |
+| `reusable-lhci.yml` | Lighthouse CI audits (a11y, perf, SEO, best-practices) |
 | `reusable-release.yml` | CHANGELOG-driven release creation |
 | `reusable-pr-validation.yml` | CHANGELOG entry validation |
 | `reusable-conventional-commits.yml` | Commit message format validation |

--- a/README.md
+++ b/README.md
@@ -68,6 +68,37 @@ jobs:
       wp-versions: '["latest", "6.4"]'
 ```
 
+### `reusable-lhci.yml`
+
+Lighthouse CI audit pipeline. Runs accessibility, performance, SEO, and best-practices audits against one or more URLs.
+
+The caller workflow is responsible for having a running site before invoking this workflow, unless `setup-wp-env`
+is enabled. When `setup-wp-env` is `true`, the workflow starts a wp-env Docker environment at
+`http://localhost:8888`.
+
+| Input | Type | Default | Description |
+|-------|------|---------|-------------|
+| `urls` | string (JSON) | `["http://localhost:8888"]` | URLs to audit |
+| `node-version` | string | `"22"` | Node.js version |
+| `runs` | number | `3` | Lighthouse runs per URL (median is used) |
+| `setup-wp-env` | boolean | `false` | Start wp-env before running audits |
+| `a11y-threshold` | number | `90` | Minimum accessibility score (0 to skip) |
+| `performance-threshold` | number | `0` | Minimum performance score (0 to skip) |
+| `seo-threshold` | number | `0` | Minimum SEO score (0 to skip) |
+| `best-practices-threshold` | number | `0` | Minimum best practices score (0 to skip) |
+| `config-path` | string | `""` | Path to `.lighthouserc.js` (overrides thresholds) |
+
+```yaml
+jobs:
+  lighthouse:
+    uses: apermo/reusable-workflows/.github/workflows/reusable-lhci.yml@main
+    with:
+      urls: '["http://localhost:8888", "http://localhost:8888/sample-page/"]'
+      setup-wp-env: true
+      a11y-threshold: 90
+      performance-threshold: 50
+```
+
 ### `reusable-ci.yml`
 
 PHP CI pipeline with configurable test matrix, PHPStan, and PHPCS.


### PR DESCRIPTION
## Summary

- Add `reusable-lhci.yml` workflow with configurable score thresholds for accessibility, performance, SEO, and best practices
- Support for wp-env setup, custom config files, and multi-URL audits
- Document the new workflow in README.md, CLAUDE.md, and CHANGELOG.md

## Test plan

- [ ] Verify workflow YAML is valid and all inputs have correct types/defaults
- [ ] Test with `setup-wp-env: true` in a consuming repo to confirm wp-env starts correctly
- [ ] Test with custom `config-path` to verify config override works
- [ ] Test threshold assertions: set `a11y-threshold: 100` and confirm failure on a non-perfect page
- [ ] Verify Lighthouse report artifact is uploaded on both success and failure

Closes #17