### PR TITLE
fix(e2e): patch wp-env for Composer 2.8 advisory

### DIFF
--- a/.github/workflows/reusable-lhci.yml
+++ b/.github/workflows/reusable-lhci.yml
@@ -88,12 +88,21 @@ jobs:
                       echo "::warning::No wp-env Dockerfile found — upstream may have moved it. See https://github.com/WordPress/gutenberg/issues/77470"
                       exit 0
                   fi
+                  patched_any=false
                   while IFS= read -r f; do
+                      if grep -qE 'COMPOSER_NO_AUDIT=1|--no-audit' "$f"; then
+                          echo "Already patched: $f"
+                          continue
+                      fi
                       if grep -q 'composer global require' "$f"; then
                           sed -i 's|composer global require|COMPOSER_NO_AUDIT=1 composer global require --no-audit|g' "$f"
                           echo "Patched: $f"
+                          patched_any=true
                       fi
                   done <<< "$DOCKERFILES"
+                  if [ "$patched_any" = false ]; then
+                      echo "::warning::No wp-env Dockerfile required patching — upstream may have changed. See https://github.com/WordPress/gutenberg/issues/77470"
+                  fi
 
             - name: Validate wp-env configuration
               if: inputs.setup-wp-env

--- a/.github/workflows/reusable-lhci.yml
+++ b/.github/workflows/reusable-lhci.yml
@@ -79,6 +79,22 @@ jobs:
               if: inputs.setup-wp-env
               run: npm install -g @wordpress/env
 
+            - name: Patch wp-env Dockerfile for Composer 2.8 advisory block
+              if: inputs.setup-wp-env
+              run: |
+                  WP_ENV_PATH="$(npm root -g)/@wordpress/env"
+                  DOCKERFILES=$(find "$WP_ENV_PATH" -type f -name 'Dockerfile*')
+                  if [ -z "$DOCKERFILES" ]; then
+                      echo "::warning::No wp-env Dockerfile found — upstream may have moved it. See https://github.com/WordPress/gutenberg/issues/77470"
+                      exit 0
+                  fi
+                  while IFS= read -r f; do
+                      if grep -q 'composer global require' "$f"; then
+                          sed -i 's|composer global require|COMPOSER_NO_AUDIT=1 composer global require --no-audit|g' "$f"
+                          echo "Patched: $f"
+                      fi
+                  done <<< "$DOCKERFILES"
+
             - name: Validate wp-env configuration
               if: inputs.setup-wp-env
               run: |

--- a/.github/workflows/reusable-wp-e2e.yml
+++ b/.github/workflows/reusable-wp-e2e.yml
@@ -91,6 +91,21 @@ jobs:
             - name: Install wp-env
               run: npm install -g @wordpress/env
 
+            - name: Patch wp-env Dockerfile for Composer 2.8 advisory block
+              run: |
+                  WP_ENV_PATH="$(npm root -g)/@wordpress/env"
+                  DOCKERFILES=$(find "$WP_ENV_PATH" -type f -name 'Dockerfile*')
+                  if [ -z "$DOCKERFILES" ]; then
+                      echo "::warning::No wp-env Dockerfile found — upstream may have moved it. See https://github.com/WordPress/gutenberg/issues/77470"
+                      exit 0
+                  fi
+                  while IFS= read -r f; do
+                      if grep -q 'composer global require' "$f"; then
+                          sed -i 's|composer global require|COMPOSER_NO_AUDIT=1 composer global require --no-audit|g' "$f"
+                          echo "Patched: $f"
+                      fi
+                  done <<< "$DOCKERFILES"
+
             - name: Validate wp-env configuration
               run: |
                   if [ ! -f .wp-env.json ]; then

--- a/.github/workflows/reusable-wp-e2e.yml
+++ b/.github/workflows/reusable-wp-e2e.yml
@@ -99,12 +99,21 @@ jobs:
                       echo "::warning::No wp-env Dockerfile found — upstream may have moved it. See https://github.com/WordPress/gutenberg/issues/77470"
                       exit 0
                   fi
+                  patched_any=false
                   while IFS= read -r f; do
+                      if grep -qE 'COMPOSER_NO_AUDIT=1|--no-audit' "$f"; then
+                          echo "Already patched: $f"
+                          continue
+                      fi
                       if grep -q 'composer global require' "$f"; then
                           sed -i 's|composer global require|COMPOSER_NO_AUDIT=1 composer global require --no-audit|g' "$f"
                           echo "Patched: $f"
+                          patched_any=true
                       fi
                   done <<< "$DOCKERFILES"
+                  if [ "$patched_any" = false ]; then
+                      echo "::warning::No wp-env Dockerfile required patching — upstream may have changed. See https://github.com/WordPress/gutenberg/issues/77470"
+                  fi
 
             - name: Validate wp-env configuration
               run: |

--- a/.github/workflows/reusable-wp-visual-regression.yml
+++ b/.github/workflows/reusable-wp-visual-regression.yml
@@ -104,6 +104,21 @@ jobs:
             - name: Install wp-env
               run: npm install -g @wordpress/env
 
+            - name: Patch wp-env Dockerfile for Composer 2.8 advisory block
+              run: |
+                  WP_ENV_PATH="$(npm root -g)/@wordpress/env"
+                  DOCKERFILES=$(find "$WP_ENV_PATH" -type f -name 'Dockerfile*')
+                  if [ -z "$DOCKERFILES" ]; then
+                      echo "::warning::No wp-env Dockerfile found — upstream may have moved it. See https://github.com/WordPress/gutenberg/issues/77470"
+                      exit 0
+                  fi
+                  while IFS= read -r f; do
+                      if grep -q 'composer global require' "$f"; then
+                          sed -i 's|composer global require|COMPOSER_NO_AUDIT=1 composer global require --no-audit|g' "$f"
+                          echo "Patched: $f"
+                      fi
+                  done <<< "$DOCKERFILES"
+
             - name: Validate wp-env configuration
               run: |
                   if [ ! -f .wp-env.json ]; then

--- a/.github/workflows/reusable-wp-visual-regression.yml
+++ b/.github/workflows/reusable-wp-visual-regression.yml
@@ -112,12 +112,21 @@ jobs:
                       echo "::warning::No wp-env Dockerfile found — upstream may have moved it. See https://github.com/WordPress/gutenberg/issues/77470"
                       exit 0
                   fi
+                  patched_any=false
                   while IFS= read -r f; do
+                      if grep -qE 'COMPOSER_NO_AUDIT=1|--no-audit' "$f"; then
+                          echo "Already patched: $f"
+                          continue
+                      fi
                       if grep -q 'composer global require' "$f"; then
                           sed -i 's|composer global require|COMPOSER_NO_AUDIT=1 composer global require --no-audit|g' "$f"
                           echo "Patched: $f"
+                          patched_any=true
                       fi
                   done <<< "$DOCKERFILES"
+                  if [ "$patched_any" = false ]; then
+                      echo "::warning::No wp-env Dockerfile required patching — upstream may have changed. See https://github.com/WordPress/gutenberg/issues/77470"
+                  fi
 
             - name: Validate wp-env configuration
               run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2026-04-18
+
+### Fixed
+
+- `reusable-wp-e2e.yml`, `reusable-wp-visual-regression.yml`, `reusable-lhci.yml` — patch wp-env Dockerfile to disable Composer 2.8 advisory blocking on PHPUnit install ([WordPress/gutenberg#77470](https://github.com/WordPress/gutenberg/issues/77470))
+
 ## [0.4.0] - 2026-04-08
 
 ### Added


### PR DESCRIPTION
## Summary

- Patch wp-env's shipped Dockerfile after install to disable Composer audits during the \`tests-cli\` image build
- Applies to \`reusable-wp-e2e.yml\`, \`reusable-wp-visual-regression.yml\`, and \`reusable-lhci.yml\` (when \`setup-wp-env: true\`)

## Root cause

Composer 2.8 (late 2024) started rejecting packages with known security advisories by default. wp-env's \`tests-cli\` Dockerfile runs \`composer global require --dev phpunit/phpunit:"^5.7.21 || ^6.0 || ... || ^10.0"\`, and every version in that range has transitive deps affected by \`PKSA-5jz8-6tcw-pbk4\` and \`PKSA-z3gr-8qht-p93v\`. The build fails with exit code 2.

## Workaround

After \`npm install -g @wordpress/env\`, find the shipped Dockerfiles and \`sed\`-inject \`COMPOSER_NO_AUDIT=1\` + \`--no-audit\` into the composer command. The step no-ops with a warning if the upstream Dockerfile layout changes.

## Upstream

Filed WordPress/gutenberg#77470. Revert this workaround once upstream lands a fix.

## Test plan

- [ ] Point a consumer E2E caller at \`@fix/wp-env-composer-advisory\` and confirm \`wp-env start\` completes
- [ ] Verify the patch step prints \`Patched: ...\` lines for at least one Dockerfile
- [ ] Verify unchanged behavior when \`setup-wp-env\` is false in \`reusable-lhci.yml\`