### PR TITLE
fix(e2e): use audit.block-insecure false for 2.8

### DIFF
--- a/.github/workflows/reusable-lhci.yml
+++ b/.github/workflows/reusable-lhci.yml
@@ -90,12 +90,12 @@ jobs:
                   fi
                   patched_any=false
                   while IFS= read -r f; do
-                      if grep -qE 'COMPOSER_NO_AUDIT=1|--no-audit' "$f"; then
+                      if grep -q 'audit.block-insecure' "$f"; then
                           echo "Already patched: $f"
                           continue
                       fi
                       if grep -q 'composer global require' "$f"; then
-                          sed -i 's|composer global require|COMPOSER_NO_AUDIT=1 composer global require --no-audit|g' "$f"
+                          sed -i 's|composer global require|composer config --global audit.block-insecure false \&\& composer global require|g' "$f"
                           echo "Patched: $f"
                           patched_any=true
                       fi

--- a/.github/workflows/reusable-wp-e2e.yml
+++ b/.github/workflows/reusable-wp-e2e.yml
@@ -101,12 +101,12 @@ jobs:
                   fi
                   patched_any=false
                   while IFS= read -r f; do
-                      if grep -qE 'COMPOSER_NO_AUDIT=1|--no-audit' "$f"; then
+                      if grep -q 'audit.block-insecure' "$f"; then
                           echo "Already patched: $f"
                           continue
                       fi
                       if grep -q 'composer global require' "$f"; then
-                          sed -i 's|composer global require|COMPOSER_NO_AUDIT=1 composer global require --no-audit|g' "$f"
+                          sed -i 's|composer global require|composer config --global audit.block-insecure false \&\& composer global require|g' "$f"
                           echo "Patched: $f"
                           patched_any=true
                       fi

--- a/.github/workflows/reusable-wp-visual-regression.yml
+++ b/.github/workflows/reusable-wp-visual-regression.yml
@@ -114,12 +114,12 @@ jobs:
                   fi
                   patched_any=false
                   while IFS= read -r f; do
-                      if grep -qE 'COMPOSER_NO_AUDIT=1|--no-audit' "$f"; then
+                      if grep -q 'audit.block-insecure' "$f"; then
                           echo "Already patched: $f"
                           continue
                       fi
                       if grep -q 'composer global require' "$f"; then
-                          sed -i 's|composer global require|COMPOSER_NO_AUDIT=1 composer global require --no-audit|g' "$f"
+                          sed -i 's|composer global require|composer config --global audit.block-insecure false \&\& composer global require|g' "$f"
                           echo "Patched: $f"
                           patched_any=true
                       fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.2] - 2026-04-18
+
+### Fixed
+
+- `reusable-wp-e2e.yml`, `reusable-wp-visual-regression.yml`, `reusable-lhci.yml` — use `composer config audit.block-insecure false` to actually disable Composer 2.8 resolution-time advisory block (`--no-audit` in 0.4.1 only skipped post-install audit) (#24)
+
 ## [0.4.1] - 2026-04-18
 
 ### Fixed


### PR DESCRIPTION
## Summary

- Replace the 0.4.1 patch's `--no-audit` / `COMPOSER_NO_AUDIT=1` (which only affect post-install audit) with `composer config --global audit.block-insecure false`, which is what actually governs resolution-time advisory blocking
- Applies to `reusable-wp-e2e.yml`, `reusable-wp-visual-regression.yml`, and `reusable-lhci.yml` (when `setup-wp-env: true`)

Closes #24. Upstream: WordPress/gutenberg#77470.

## Why 0.4.1 didn't work

Composer's output itself pointed at the right toggle:

> To ignore the advisories, add them to the audit "ignore" config. To turn the feature off entirely, you can set "block-insecure" to false in your "audit" config.

`--no-audit` / `COMPOSER_NO_AUDIT=1` both only skip the post-install audit step. The "these were not loaded, because they are affected by security advisories" error fires during package resolution, which runs before any audit and is controlled by `audit.block-insecure`.

The 0.4.1 `sed` rewrote the command but didn't change the failing behavior — both `cli` and `tests-cli` images still failed to build.

## Test plan

- [ ] Point a consumer E2E caller at `@fix/wp-env-composer-block-insecure` and confirm `wp-env start` completes
- [ ] Verify the patch step prints `Patched: ...` for both `cli` and `tests-cli` Dockerfiles
- [ ] Verify idempotency — running twice doesn't double-inject