### PR TITLE
fix(e2e): patch wp-env JS source, not Dockerfiles

### DIFF
--- a/.github/workflows/reusable-lhci.yml
+++ b/.github/workflows/reusable-lhci.yml
@@ -79,29 +79,21 @@ jobs:
               if: inputs.setup-wp-env
               run: npm install -g @wordpress/env
 
-            - name: Patch wp-env Dockerfile for Composer 2.8 advisory block
+            - name: Patch wp-env source for Composer 2.8 advisory block
               if: inputs.setup-wp-env
               run: |
-                  WP_ENV_PATH="$(npm root -g)/@wordpress/env"
-                  DOCKERFILES=$(find "$WP_ENV_PATH" -type f -name 'Dockerfile*')
-                  if [ -z "$DOCKERFILES" ]; then
-                      echo "::warning::No wp-env Dockerfile found — upstream may have moved it. See https://github.com/WordPress/gutenberg/issues/77470"
+                  DOCKER_CONFIG="$(npm root -g)/@wordpress/env/lib/runtime/docker/docker-config.js"
+                  if [ ! -f "$DOCKER_CONFIG" ]; then
+                      echo "::warning::wp-env docker-config.js not found — upstream may have moved it. See https://github.com/WordPress/gutenberg/issues/77470"
                       exit 0
                   fi
-                  patched_any=false
-                  while IFS= read -r f; do
-                      if grep -q 'audit.block-insecure' "$f"; then
-                          echo "Already patched: $f"
-                          continue
-                      fi
-                      if grep -q 'composer global require' "$f"; then
-                          sed -i 's|composer global require|composer config --global audit.block-insecure false \&\& composer global require|g' "$f"
-                          echo "Patched: $f"
-                          patched_any=true
-                      fi
-                  done <<< "$DOCKERFILES"
-                  if [ "$patched_any" = false ]; then
-                      echo "::warning::No wp-env Dockerfile required patching — upstream may have changed. See https://github.com/WordPress/gutenberg/issues/77470"
+                  if grep -q 'audit.block-insecure' "$DOCKER_CONFIG"; then
+                      echo "Already patched: $DOCKER_CONFIG"
+                  elif grep -q 'RUN composer global require' "$DOCKER_CONFIG"; then
+                      sed -i 's|RUN composer global require|RUN composer config --global audit.block-insecure false \&\& composer global require|g' "$DOCKER_CONFIG"
+                      echo "Patched: $DOCKER_CONFIG"
+                  else
+                      echo "::warning::No 'RUN composer global require' found in $DOCKER_CONFIG — upstream may have changed. See https://github.com/WordPress/gutenberg/issues/77470"
                   fi
 
             - name: Validate wp-env configuration

--- a/.github/workflows/reusable-wp-e2e.yml
+++ b/.github/workflows/reusable-wp-e2e.yml
@@ -91,28 +91,20 @@ jobs:
             - name: Install wp-env
               run: npm install -g @wordpress/env
 
-            - name: Patch wp-env Dockerfile for Composer 2.8 advisory block
+            - name: Patch wp-env source for Composer 2.8 advisory block
               run: |
-                  WP_ENV_PATH="$(npm root -g)/@wordpress/env"
-                  DOCKERFILES=$(find "$WP_ENV_PATH" -type f -name 'Dockerfile*')
-                  if [ -z "$DOCKERFILES" ]; then
-                      echo "::warning::No wp-env Dockerfile found — upstream may have moved it. See https://github.com/WordPress/gutenberg/issues/77470"
+                  DOCKER_CONFIG="$(npm root -g)/@wordpress/env/lib/runtime/docker/docker-config.js"
+                  if [ ! -f "$DOCKER_CONFIG" ]; then
+                      echo "::warning::wp-env docker-config.js not found — upstream may have moved it. See https://github.com/WordPress/gutenberg/issues/77470"
                       exit 0
                   fi
-                  patched_any=false
-                  while IFS= read -r f; do
-                      if grep -q 'audit.block-insecure' "$f"; then
-                          echo "Already patched: $f"
-                          continue
-                      fi
-                      if grep -q 'composer global require' "$f"; then
-                          sed -i 's|composer global require|composer config --global audit.block-insecure false \&\& composer global require|g' "$f"
-                          echo "Patched: $f"
-                          patched_any=true
-                      fi
-                  done <<< "$DOCKERFILES"
-                  if [ "$patched_any" = false ]; then
-                      echo "::warning::No wp-env Dockerfile required patching — upstream may have changed. See https://github.com/WordPress/gutenberg/issues/77470"
+                  if grep -q 'audit.block-insecure' "$DOCKER_CONFIG"; then
+                      echo "Already patched: $DOCKER_CONFIG"
+                  elif grep -q 'RUN composer global require' "$DOCKER_CONFIG"; then
+                      sed -i 's|RUN composer global require|RUN composer config --global audit.block-insecure false \&\& composer global require|g' "$DOCKER_CONFIG"
+                      echo "Patched: $DOCKER_CONFIG"
+                  else
+                      echo "::warning::No 'RUN composer global require' found in $DOCKER_CONFIG — upstream may have changed. See https://github.com/WordPress/gutenberg/issues/77470"
                   fi
 
             - name: Validate wp-env configuration

--- a/.github/workflows/reusable-wp-visual-regression.yml
+++ b/.github/workflows/reusable-wp-visual-regression.yml
@@ -104,28 +104,20 @@ jobs:
             - name: Install wp-env
               run: npm install -g @wordpress/env
 
-            - name: Patch wp-env Dockerfile for Composer 2.8 advisory block
+            - name: Patch wp-env source for Composer 2.8 advisory block
               run: |
-                  WP_ENV_PATH="$(npm root -g)/@wordpress/env"
-                  DOCKERFILES=$(find "$WP_ENV_PATH" -type f -name 'Dockerfile*')
-                  if [ -z "$DOCKERFILES" ]; then
-                      echo "::warning::No wp-env Dockerfile found — upstream may have moved it. See https://github.com/WordPress/gutenberg/issues/77470"
+                  DOCKER_CONFIG="$(npm root -g)/@wordpress/env/lib/runtime/docker/docker-config.js"
+                  if [ ! -f "$DOCKER_CONFIG" ]; then
+                      echo "::warning::wp-env docker-config.js not found — upstream may have moved it. See https://github.com/WordPress/gutenberg/issues/77470"
                       exit 0
                   fi
-                  patched_any=false
-                  while IFS= read -r f; do
-                      if grep -q 'audit.block-insecure' "$f"; then
-                          echo "Already patched: $f"
-                          continue
-                      fi
-                      if grep -q 'composer global require' "$f"; then
-                          sed -i 's|composer global require|composer config --global audit.block-insecure false \&\& composer global require|g' "$f"
-                          echo "Patched: $f"
-                          patched_any=true
-                      fi
-                  done <<< "$DOCKERFILES"
-                  if [ "$patched_any" = false ]; then
-                      echo "::warning::No wp-env Dockerfile required patching — upstream may have changed. See https://github.com/WordPress/gutenberg/issues/77470"
+                  if grep -q 'audit.block-insecure' "$DOCKER_CONFIG"; then
+                      echo "Already patched: $DOCKER_CONFIG"
+                  elif grep -q 'RUN composer global require' "$DOCKER_CONFIG"; then
+                      sed -i 's|RUN composer global require|RUN composer config --global audit.block-insecure false \&\& composer global require|g' "$DOCKER_CONFIG"
+                      echo "Patched: $DOCKER_CONFIG"
+                  else
+                      echo "::warning::No 'RUN composer global require' found in $DOCKER_CONFIG — upstream may have changed. See https://github.com/WordPress/gutenberg/issues/77470"
                   fi
 
             - name: Validate wp-env configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `reusable-wp-e2e.yml`, `reusable-wp-visual-regression.yml`, `reusable-lhci.yml` — patch the wp-env JS source (`docker-config.js`) instead of searching for static Dockerfiles. wp-env generates Dockerfiles at runtime under `~/.wp-env/` as `*.Dockerfile`, so the 0.4.1/0.4.2 find-and-sed approach never matched. (#24)
+- `reusable-wp-e2e.yml`, `reusable-wp-visual-regression.yml`, `reusable-lhci.yml` — patch the wp-env JS source (`docker-config.js`) instead of searching for static Dockerfiles. wp-env generates Dockerfiles at runtime under `~/.wp-env/` as `*.Dockerfile`, so the 0.4.1/0.4.2 find-and-sed approach never matched. (#24, [WordPress/gutenberg#77470](https://github.com/WordPress/gutenberg/issues/77470))
 
 ## [0.4.2] - 2026-04-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.3] - 2026-04-18
+
+### Fixed
+
+- `reusable-wp-e2e.yml`, `reusable-wp-visual-regression.yml`, `reusable-lhci.yml` — patch the wp-env JS source (`docker-config.js`) instead of searching for static Dockerfiles. wp-env generates Dockerfiles at runtime under `~/.wp-env/` as `*.Dockerfile`, so the 0.4.1/0.4.2 find-and-sed approach never matched. (#24)
+
 ## [0.4.2] - 2026-04-18
 
 ### Fixed


### PR DESCRIPTION
## Summary

- Replace the `find node_modules -name 'Dockerfile*'` approach with a targeted patch of `docker-config.js`
- wp-env generates Dockerfiles at runtime under `~/.wp-env/<hash>/` with names like `Tests-CLI.Dockerfile`, not shipped under `node_modules`. The 0.4.1/0.4.2 patch steps always logged "No wp-env Dockerfile found" and exited without doing anything.
- By patching the JS template source once, the correct `composer config --global audit.block-insecure false && composer global require …` ends up in every generated Dockerfile from the first build.

Closes #24. Upstream: WordPress/gutenberg#77470.

## Why 0.4.1 and 0.4.2 didn't work

`@wordpress/env` does not ship static Dockerfiles. `packages/env/lib/runtime/docker/docker-config.js` builds them as template strings at `wp-env start` time and writes them to `~/.wp-env/<hash>/*.Dockerfile`. Our patch step runs before `wp-env start`, so:

1. There are no files to find yet (nothing in `~/.wp-env/` either at that point).
2. `find … -name 'Dockerfile*'` wouldn't match `*.Dockerfile` even if they existed.

Patching the JS source (`$(npm root -g)/@wordpress/env/lib/runtime/docker/docker-config.js`) gets around both problems — the next `wp-env start` generates correct Dockerfiles directly.

## Test plan

- [ ] Point a consumer E2E caller at `@fix/wp-env-patch-js-source` and confirm `wp-env start` completes (image build no longer blocked by PKSA advisories)
- [ ] Verify the step prints `Patched: .../docker-config.js`
- [ ] Verify idempotency — running twice doesn't re-patch (second run should log `Already patched: ...`)