### PR TITLE
feat: add reusable-plugin-check.yml

### DIFF
--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -38,6 +38,9 @@ on:
                 description: 'Codecov upload token'
                 required: false
 
+permissions:
+    contents: read
+
 jobs:
     test:
         name: Tests (PHP ${{ matrix.php }})

--- a/.github/workflows/reusable-lhci.yml
+++ b/.github/workflows/reusable-lhci.yml
@@ -54,6 +54,9 @@ on:
                 type: string
                 default: 'lighthouse-report'
 
+permissions:
+    contents: read
+
 jobs:
     lighthouse:
         name: Lighthouse CI

--- a/.github/workflows/reusable-plugin-check.yml
+++ b/.github/workflows/reusable-plugin-check.yml
@@ -59,12 +59,13 @@ on:
                 type: boolean
                 default: false
 
+permissions:
+    contents: read
+
 jobs:
     plugin-check:
         name: Plugin Check
         runs-on: ubuntu-latest
-        permissions:
-            contents: read
         steps:
             - uses: actions/checkout@v4
 

--- a/.github/workflows/reusable-plugin-check.yml
+++ b/.github/workflows/reusable-plugin-check.yml
@@ -1,0 +1,84 @@
+name: WP Plugin Check
+
+on:
+    workflow_call:
+        inputs:
+            wp-version:
+                description: 'WordPress version to test against'
+                required: false
+                type: string
+                default: 'latest'
+            build-dir:
+                description: 'Plugin build directory'
+                required: false
+                type: string
+                default: './'
+            checks:
+                description: 'Only run specific checks (comma-separated)'
+                required: false
+                type: string
+                default: ''
+            exclude-checks:
+                description: 'Checks to exclude (comma-separated)'
+                required: false
+                type: string
+                default: ''
+            categories:
+                description: 'Limit checks to specific categories (comma-separated)'
+                required: false
+                type: string
+                default: ''
+            exclude-files:
+                description: 'Files to exclude from checks (comma-separated)'
+                required: false
+                type: string
+                default: ''
+            exclude-directories:
+                description: 'Directories to exclude from checks (comma-separated)'
+                required: false
+                type: string
+                default: ''
+            ignore-codes:
+                description: 'Error codes to ignore (comma-separated)'
+                required: false
+                type: string
+                default: ''
+            ignore-warnings:
+                description: 'Ignore warnings'
+                required: false
+                type: boolean
+                default: false
+            ignore-errors:
+                description: 'Ignore errors'
+                required: false
+                type: boolean
+                default: false
+            include-experimental:
+                description: 'Include experimental checks'
+                required: false
+                type: boolean
+                default: false
+
+jobs:
+    plugin-check:
+        name: Plugin Check
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        steps:
+            - uses: actions/checkout@v4
+
+            - uses: wordpress/plugin-check-action@v1
+              with:
+                  repo-token: ${{ github.token }}
+                  wp-version: ${{ inputs.wp-version }}
+                  build-dir: ${{ inputs.build-dir }}
+                  checks: ${{ inputs.checks }}
+                  exclude-checks: ${{ inputs.exclude-checks }}
+                  categories: ${{ inputs.categories }}
+                  exclude-files: ${{ inputs.exclude-files }}
+                  exclude-directories: ${{ inputs.exclude-directories }}
+                  ignore-codes: ${{ inputs.ignore-codes }}
+                  ignore-warnings: ${{ inputs.ignore-warnings }}
+                  ignore-errors: ${{ inputs.ignore-errors }}
+                  include-experimental: ${{ inputs.include-experimental }}

--- a/.github/workflows/reusable-wp-e2e.yml
+++ b/.github/workflows/reusable-wp-e2e.yml
@@ -29,6 +29,9 @@ on:
                 type: boolean
                 default: false
 
+permissions:
+    contents: read
+
 jobs:
     matrix-prep:
         name: Prepare matrix

--- a/.github/workflows/reusable-wp-integration.yml
+++ b/.github/workflows/reusable-wp-integration.yml
@@ -38,6 +38,9 @@ on:
                 description: 'Codecov upload token'
                 required: false
 
+permissions:
+    contents: read
+
 jobs:
     matrix-prep:
         name: Prepare matrix

--- a/.github/workflows/reusable-wp-theme-ci.yml
+++ b/.github/workflows/reusable-wp-theme-ci.yml
@@ -49,6 +49,9 @@ on:
                 type: string
                 default: 'version.php'
 
+permissions:
+    contents: read
+
 jobs:
     eslint:
         name: ESLint

--- a/.github/workflows/reusable-wp-visual-regression.yml
+++ b/.github/workflows/reusable-wp-visual-regression.yml
@@ -44,6 +44,9 @@ on:
                 type: string
                 default: '["light"]'
 
+permissions:
+    contents: read
+
 jobs:
     matrix-prep:
         name: Prepare matrix

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `reusable-plugin-check.yml` — WordPress Plugin Check runner wrapping [`wordpress/plugin-check-action@v1`](https://github.com/WordPress/plugin-check-action). Exposes the 11 most commonly tuned inputs and sets `permissions: contents: read` at the job level. (#27)
+- `reusable-plugin-check.yml` — WordPress Plugin Check runner wrapping [`wordpress/plugin-check-action@v1`](https://github.com/WordPress/plugin-check-action). Exposes the 11 most commonly tuned inputs. (#27)
+
+### Changed
+
+- `reusable-ci.yml`, `reusable-wp-integration.yml`, `reusable-wp-e2e.yml`, `reusable-wp-visual-regression.yml`, `reusable-wp-theme-ci.yml`, `reusable-lhci.yml`, `reusable-plugin-check.yml` — declare explicit `permissions: contents: read` at the workflow level. Defense-in-depth: the reusables now scope their own `GITHUB_TOKEN` instead of inheriting whatever the caller grants. (#28)
 
 ## [0.4.3] - 2026-04-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-04-19
+
+### Added
+
+- `reusable-plugin-check.yml` — WordPress Plugin Check runner wrapping [`wordpress/plugin-check-action@v1`](https://github.com/WordPress/plugin-check-action). Exposes the 11 most commonly tuned inputs and sets `permissions: contents: read` at the job level. (#27)
+
 ## [0.4.3] - 2026-04-18
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ violations as GitHub file annotations. Intended for plugins targeting the wordpr
 
 | Input | Type | Default | Description |
 |-------|------|---------|-------------|
-| `wp-version` | string | `"latest"` | WordPress version to test against |
+| `wp-version` | string | `"latest"` | WordPress version (`"latest"` or `"trunk"`; upstream only special-cases `trunk`) |
 | `build-dir` | string | `"./"` | Plugin build directory |
 | `checks` | string | `""` | Only run specific checks (comma-separated) |
 | `exclude-checks` | string | `""` | Checks to exclude (comma-separated) |

--- a/README.md
+++ b/README.md
@@ -156,6 +156,34 @@ jobs:
       color-schemes: '["light", "dark"]'
 ```
 
+### `reusable-plugin-check.yml`
+
+WordPress [Plugin Check](https://wordpress.org/plugins/plugin-check/) runner. Wraps
+[`wordpress/plugin-check-action@v1`](https://github.com/WordPress/plugin-check-action) and reports guideline
+violations as GitHub file annotations. Intended for plugins targeting the wordpress.org plugin directory.
+
+| Input | Type | Default | Description |
+|-------|------|---------|-------------|
+| `wp-version` | string | `"latest"` | WordPress version to test against |
+| `build-dir` | string | `"./"` | Plugin build directory |
+| `checks` | string | `""` | Only run specific checks (comma-separated) |
+| `exclude-checks` | string | `""` | Checks to exclude (comma-separated) |
+| `categories` | string | `""` | Limit checks to specific categories (comma-separated) |
+| `exclude-files` | string | `""` | Files to exclude (comma-separated) |
+| `exclude-directories` | string | `""` | Directories to exclude (comma-separated) |
+| `ignore-codes` | string | `""` | Error codes to ignore (comma-separated) |
+| `ignore-warnings` | boolean | `false` | Ignore warnings |
+| `ignore-errors` | boolean | `false` | Ignore errors |
+| `include-experimental` | boolean | `false` | Include experimental checks |
+
+```yaml
+jobs:
+  plugin-check:
+    uses: apermo/reusable-workflows/.github/workflows/reusable-plugin-check.yml@main
+    with:
+      wp-version: latest
+```
+
 ### `reusable-ci.yml`
 
 PHP CI pipeline with configurable test matrix, PHPStan, and PHPCS.


### PR DESCRIPTION
## Summary

- Adds `reusable-plugin-check.yml` wrapping [`wordpress/plugin-check-action@v1`](https://github.com/WordPress/plugin-check-action) as a consistent entry point for the WordPress Plugin Check across apermo plugin repos (11 of 18 upstream inputs exposed; rationale in [scope comment](https://github.com/apermo/reusable-workflows/issues/27#issuecomment-4275784194)).
- Retrofits explicit `permissions: contents: read` at the **workflow level** on the other 6 CI-type reusables (`reusable-ci`, `reusable-wp-integration`, `reusable-wp-e2e`, `reusable-wp-visual-regression`, `reusable-wp-theme-ci`, `reusable-lhci`) and aligns the new plugin-check workflow to match. Defense in depth — reusables scope their own `GITHUB_TOKEN` rather than inheriting whatever the caller grants.
- Hard-codes `repo-token: ${{ github.token }}` inside plugin-check — no caller input needed.
- README section + 0.5.0 CHANGELOG entry for both changes.

## Scope decisions

Discussed in #27; refined scope posted as an [issue comment](https://github.com/apermo/reusable-workflows/issues/27#issuecomment-4275784194).

Permissions retrofit scoped in #28; bundled here at user request.

## Commits

Atomic, one topic per commit (cherry-pickable):

- `feat: add reusable-plugin-check.yml`
- `docs: changelog entry for 0.5.0`
- `docs: clarify wp-version accepted values` (addresses review feedback on the README input table)
- `refactor(plugin-check): move permissions to workflow level`
- `refactor(ci): set explicit contents: read permissions`
- `refactor(wp-integration): set explicit contents: read permissions`
- `refactor(wp-e2e): set explicit contents: read permissions`
- `refactor(wp-visual-regression): add explicit contents: read`
- `refactor(wp-theme-ci): set explicit contents: read permissions`
- `refactor(lhci): set explicit contents: read permissions`
- `docs: note CI permissions retrofit in 0.5.0`

## Follow-up

- apermo/template-wordpress#37 will swap its direct `wordpress/plugin-check-action@v1` call for `uses: apermo/reusable-workflows/.github/workflows/reusable-plugin-check.yml@v0.5.0` once this ships.

## Test plan

- [ ] actionlint passes on all modified workflows (pre-existing shellcheck advisories in `reusable-wp-e2e.yml` / `reusable-wp-visual-regression.yml` / `reusable-release.yml` are unrelated)
- [ ] PR validation workflow recognizes the 0.5.0 CHANGELOG entry
- [ ] Conventional-commits check passes on all commits
- [ ] Self-CI run of `reusable-ci.yml` still passes under the new `permissions: contents: read` scope
- [ ] After merge and release, verify downstream call works from a test branch in a plugin repo before updating apermo/template-wordpress#37

Closes #27
Closes #28