### PR TITLE
fix(wp-env): drop Composer 2.8 audit workaround

### DIFF
--- a/.github/workflows/reusable-lhci.yml
+++ b/.github/workflows/reusable-lhci.yml
@@ -82,23 +82,6 @@ jobs:
               if: inputs.setup-wp-env
               run: npm install -g @wordpress/env
 
-            - name: Patch wp-env source for Composer 2.8 advisory block
-              if: inputs.setup-wp-env
-              run: |
-                  DOCKER_CONFIG="$(npm root -g)/@wordpress/env/lib/runtime/docker/docker-config.js"
-                  if [ ! -f "$DOCKER_CONFIG" ]; then
-                      echo "::warning::wp-env docker-config.js not found — upstream may have moved it. See https://github.com/WordPress/gutenberg/issues/77470"
-                      exit 0
-                  fi
-                  if grep -q 'audit.block-insecure' "$DOCKER_CONFIG"; then
-                      echo "Already patched: $DOCKER_CONFIG"
-                  elif grep -q 'RUN composer global require' "$DOCKER_CONFIG"; then
-                      sed -i 's|RUN composer global require|RUN composer config --global audit.block-insecure false \&\& composer global require|g' "$DOCKER_CONFIG"
-                      echo "Patched: $DOCKER_CONFIG"
-                  else
-                      echo "::warning::No 'RUN composer global require' found in $DOCKER_CONFIG — upstream may have changed. See https://github.com/WordPress/gutenberg/issues/77470"
-                  fi
-
             - name: Validate wp-env configuration
               if: inputs.setup-wp-env
               run: |

--- a/.github/workflows/reusable-wp-e2e.yml
+++ b/.github/workflows/reusable-wp-e2e.yml
@@ -94,22 +94,6 @@ jobs:
             - name: Install wp-env
               run: npm install -g @wordpress/env
 
-            - name: Patch wp-env source for Composer 2.8 advisory block
-              run: |
-                  DOCKER_CONFIG="$(npm root -g)/@wordpress/env/lib/runtime/docker/docker-config.js"
-                  if [ ! -f "$DOCKER_CONFIG" ]; then
-                      echo "::warning::wp-env docker-config.js not found — upstream may have moved it. See https://github.com/WordPress/gutenberg/issues/77470"
-                      exit 0
-                  fi
-                  if grep -q 'audit.block-insecure' "$DOCKER_CONFIG"; then
-                      echo "Already patched: $DOCKER_CONFIG"
-                  elif grep -q 'RUN composer global require' "$DOCKER_CONFIG"; then
-                      sed -i 's|RUN composer global require|RUN composer config --global audit.block-insecure false \&\& composer global require|g' "$DOCKER_CONFIG"
-                      echo "Patched: $DOCKER_CONFIG"
-                  else
-                      echo "::warning::No 'RUN composer global require' found in $DOCKER_CONFIG — upstream may have changed. See https://github.com/WordPress/gutenberg/issues/77470"
-                  fi
-
             - name: Validate wp-env configuration
               run: |
                   if [ ! -f .wp-env.json ]; then

--- a/.github/workflows/reusable-wp-visual-regression.yml
+++ b/.github/workflows/reusable-wp-visual-regression.yml
@@ -107,22 +107,6 @@ jobs:
             - name: Install wp-env
               run: npm install -g @wordpress/env
 
-            - name: Patch wp-env source for Composer 2.8 advisory block
-              run: |
-                  DOCKER_CONFIG="$(npm root -g)/@wordpress/env/lib/runtime/docker/docker-config.js"
-                  if [ ! -f "$DOCKER_CONFIG" ]; then
-                      echo "::warning::wp-env docker-config.js not found — upstream may have moved it. See https://github.com/WordPress/gutenberg/issues/77470"
-                      exit 0
-                  fi
-                  if grep -q 'audit.block-insecure' "$DOCKER_CONFIG"; then
-                      echo "Already patched: $DOCKER_CONFIG"
-                  elif grep -q 'RUN composer global require' "$DOCKER_CONFIG"; then
-                      sed -i 's|RUN composer global require|RUN composer config --global audit.block-insecure false \&\& composer global require|g' "$DOCKER_CONFIG"
-                      echo "Patched: $DOCKER_CONFIG"
-                  else
-                      echo "::warning::No 'RUN composer global require' found in $DOCKER_CONFIG — upstream may have changed. See https://github.com/WordPress/gutenberg/issues/77470"
-                  fi
-
             - name: Validate wp-env configuration
               run: |
                   if [ ! -f .wp-env.json ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2026-04-20
+
+### Fixed
+
+- `reusable-wp-e2e.yml`, `reusable-wp-visual-regression.yml`, `reusable-lhci.yml` — remove the `docker-config.js` sed-patch shipped in 0.4.1–0.4.3. The upstream advisory metadata that blocked Composer 2.8 resolution of PHPUnit 11 was corrected in [FriendsOfPHP/security-advisories#762](https://github.com/FriendsOfPHP/security-advisories/pull/762) (merged 2026-04-18), which is the feed Composer consults. The workaround is no longer needed; see [WordPress/gutenberg#77472](https://github.com/WordPress/gutenberg/pull/77472) for the matching upstream revert.
+
 ## [0.5.0] - 2026-04-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- `reusable-wp-e2e.yml`, `reusable-wp-visual-regression.yml`, `reusable-lhci.yml` — remove the `docker-config.js` sed-patch shipped in 0.4.1–0.4.3. The upstream advisory metadata that blocked Composer 2.8 resolution of PHPUnit 11 was corrected in [FriendsOfPHP/security-advisories#762](https://github.com/FriendsOfPHP/security-advisories/pull/762) (merged 2026-04-18), which is the feed Composer consults. The workaround is no longer needed; see [WordPress/gutenberg#77472](https://github.com/WordPress/gutenberg/pull/77472) for the matching upstream revert.
+- `reusable-wp-e2e.yml`, `reusable-wp-visual-regression.yml`, `reusable-lhci.yml` — remove the `docker-config.js`
+  sed-patch shipped in 0.4.1–0.4.3. The upstream advisory metadata that blocked Composer 2.8 resolution of
+  PHPUnit 11 was corrected in
+  [FriendsOfPHP/security-advisories#762](https://github.com/FriendsOfPHP/security-advisories/pull/762)
+  (merged 2026-04-18), which is the feed Composer consults. The workaround is no longer needed; see
+  [WordPress/gutenberg#77472](https://github.com/WordPress/gutenberg/pull/77472) for the matching upstream revert.
 
 ## [0.5.0] - 2026-04-19
 


### PR DESCRIPTION
## Summary

- Removes the `docker-config.js` sed-patch from `reusable-wp-e2e.yml`, `reusable-wp-visual-regression.yml`, and `reusable-lhci.yml`.
- Adds CHANGELOG entry for 0.5.1.

## Why

The workaround shipped in 0.4.1–0.4.3 bypassed Composer 2.8's `audit.block-insecure` filter so wp-env's `tests-cli` image could install PHPUnit 11 during `wp-env start`.

Root cause was a mis-scoped advisory (GHSA-qrr6-mg7r-m243) that flagged the full PHPUnit version range when only 12.5.21 and 13.1.5 are actually vulnerable. Sebastian Bergmann corrected the metadata in the Packagist-facing feed via [FriendsOfPHP/security-advisories#762](https://github.com/FriendsOfPHP/security-advisories/pull/762), merged 2026-04-18. That feed takes precedence over GHSA for Composer, so resolution of PHPUnit 11 works again without the override.

Gutenberg closed the parallel upstream PR [WordPress/gutenberg#77472](https://github.com/WordPress/gutenberg/pull/77472) for the same reason (thanks to @swissspidy for the heads-up).

## Test plan

- [ ] `actionlint` clean on the three modified workflows (pre-existing info warnings only).
- [ ] `reusable-wp-e2e`, `reusable-wp-visual-regression`, and `reusable-lhci` jobs in PR CI go green — these call the reusables via relative path, so PR CI is the integration test.
- [ ] If they fail with Composer exit 2 the revert is premature; otherwise the fix is verified end-to-end.