### PR TITLE
feat(stale)!: per-type timeouts for issues and PRs

### DIFF
--- a/.github/workflows/reusable-stale.yml
+++ b/.github/workflows/reusable-stale.yml
@@ -3,16 +3,26 @@ name: Reusable Stale
 on:
     workflow_call:
         inputs:
-            days-before-stale:
-                description: 'Days before marking as stale'
+            days-before-issue-stale:
+                description: 'Days of inactivity before marking an issue as stale'
                 required: false
                 type: number
                 default: 30
-            days-before-close:
-                description: 'Days before closing stale items'
+            days-before-issue-close:
+                description: 'Days after stale before closing an issue'
                 required: false
                 type: number
                 default: 14
+            days-before-pr-stale:
+                description: 'Days of inactivity before marking a PR as stale'
+                required: false
+                type: number
+                default: 60
+            days-before-pr-close:
+                description: 'Days after stale before closing a PR'
+                required: false
+                type: number
+                default: 21
             exempt-labels:
                 description: 'Comma-separated exempt labels'
                 required: false
@@ -29,8 +39,10 @@ jobs:
         steps:
             - uses: actions/stale@v10
               with:
-                  days-before-stale: ${{ inputs.days-before-stale }}
-                  days-before-close: ${{ inputs.days-before-close }}
+                  days-before-issue-stale: ${{ inputs.days-before-issue-stale }}
+                  days-before-issue-close: ${{ inputs.days-before-issue-close }}
+                  days-before-pr-stale: ${{ inputs.days-before-pr-stale }}
+                  days-before-pr-close: ${{ inputs.days-before-pr-close }}
                   stale-issue-label: stale
                   stale-pr-label: stale
                   exempt-issue-labels: ${{ inputs.exempt-labels }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.6.0] - 2026-04-28
+## [0.6.0] - 2026-05-01
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-04-28
+
+### Changed
+
+- `reusable-stale.yml` — **breaking**: replace generic `days-before-stale` / `days-before-close` inputs with four
+  per-type inputs so issues and PRs can have different timeouts. New inputs:
+  `days-before-issue-stale` (default 30), `days-before-issue-close` (default 14),
+  `days-before-pr-stale` (default 60), `days-before-pr-close` (default 21). PR defaults are roughly twice the issue
+  grace period since an open PR represents in-flight work. Callers that pass the old input names must rename them.
+
 ## [0.5.1] - 2026-04-20
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -275,8 +275,10 @@ Auto-closes stale issues and PRs.
 
 | Input | Type | Default | Description |
 |-------|------|---------|-------------|
-| `days-before-stale` | number | `30` | Days before marking stale |
-| `days-before-close` | number | `14` | Days before closing |
+| `days-before-issue-stale` | number | `30` | Days of inactivity before marking an issue as stale |
+| `days-before-issue-close` | number | `14` | Days after stale before closing an issue |
+| `days-before-pr-stale` | number | `60` | Days of inactivity before marking a PR as stale |
+| `days-before-pr-close` | number | `21` | Days after stale before closing a PR |
 | `exempt-labels` | string | `pinned,security,in-progress` | Exempt labels |
 
 ```yaml


### PR DESCRIPTION
## Summary

- Replace the generic `days-before-stale` / `days-before-close` inputs in `reusable-stale.yml` with four per-type inputs: `days-before-issue-stale` (30), `days-before-issue-close` (14), `days-before-pr-stale` (60), `days-before-pr-close` (21).
- PR defaults are roughly twice the issue grace period since an open PR represents in-flight work; issues retain today's 30/14 cadence.
- CHANGELOG entry under `## [0.6.0]`. Local `stale.yml` caller is unaffected (uses defaults).

## Breaking change

Callers that pass the old `days-before-stale` / `days-before-close` inputs must rename them. No layered fallback is provided — the new inputs are required to be set explicitly only if the caller wants to override defaults.

## Test plan

- [x] `actionlint .github/workflows/reusable-stale.yml` — clean
- [ ] Wait for or manually trigger the next scheduled `stale.yml` run and confirm `actions/stale@v10` logs the four per-type values