### PR TITLE
fix(commits): accept ! breaking-change marker in subject

### DIFF
--- a/.github/workflows/reusable-conventional-commits.yml
+++ b/.github/workflows/reusable-conventional-commits.yml
@@ -46,7 +46,7 @@ jobs:
                           continue
                       fi
 
-                      if ! echo "$MSG" | grep -qP "^(${ALLOWED_TYPES})(\(.+\))?: .{1,}$"; then
+                      if ! echo "$MSG" | grep -qP "^(${ALLOWED_TYPES})(\(.+\))?!?: .{1,}$"; then
                           echo "::error::Invalid commit message: $MSG ($HASH)"
                           FAILED=1
                       fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `reusable-conventional-commits.yml` — accept the `!` breaking-change marker in commit subjects
   (e.g. `feat(api)!: drop deprecated input`). The Conventional Commits 1.0 spec defines `!` and a
   `BREAKING CHANGE:` footer as equivalent ways to mark a breaking change; the validator regex
-  previously only accepted the footer form, rejecting spec-compliant subjects like the one used
-  for the 0.6.0 release commit.
+  previously only accepted the footer form, rejecting spec-compliant subjects like the one
+  intended for the 0.6.0 release commit (which had to be rewritten to drop the `!`).
 
 ## [0.6.0] - 2026-05-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.1] - 2026-05-01
+
+### Fixed
+
+- `reusable-conventional-commits.yml` — accept the `!` breaking-change marker in commit subjects
+  (e.g. `feat(api)!: drop deprecated input`). The Conventional Commits 1.0 spec defines `!` and a
+  `BREAKING CHANGE:` footer as equivalent ways to mark a breaking change; the validator regex
+  previously only accepted the footer form, rejecting spec-compliant subjects like the one used
+  for the 0.6.0 release commit.
+
 ## [0.6.0] - 2026-05-01
 
 ### Changed


### PR DESCRIPTION
## Summary

- Extend the regex in `reusable-conventional-commits.yml` to allow an optional `!` between the type/scope and the colon, so spec-compliant breaking-change subjects like `feat(api)!: drop x` pass validation.
- CHANGELOG entry under `## [0.6.1]`.

## Why

[Conventional Commits 1.0](https://www.conventionalcommits.org/en/v1.0.0/#specification) defines two equivalent ways to mark a breaking change:

1. A `!` after the type/scope, before the colon — e.g. `feat(stale)!: drop legacy inputs`
2. A `BREAKING CHANGE:` footer in the body

The validator regex only accepted the footer form. The 0.6.0 release commit (`feat(stale)!: per-type timeouts for issues and PRs`) was rejected by CI, forcing a rewrite of the subject to drop the `!` and rely solely on the body footer. Both forms are spec-valid; the validator should accept either.

## Change

```diff
-^(${ALLOWED_TYPES})(\(.+\))?: .{1,}$
+^(${ALLOWED_TYPES})(\(.+\))?!?: .{1,}$
```

The `!?` is zero-or-one literal `!`, composing correctly with the optional scope group.

## Test plan

Smoke-tested locally — all four spec-valid forms pass, and previously-rejected non-conventional input still rejects:

| Subject | Expected | Result |
|---------|----------|--------|
| `feat: foo` | pass | pass |
| `feat!: foo` | pass | pass |
| `feat(api): foo` | pass | pass |
| `feat(api)!: foo` | pass | pass |
| `feat(api): ` (empty subject) | reject | reject |
| `random text` | reject | reject |

- [x] `actionlint` clean
- [x] Local regex smoke test (above)
- [ ] CI on this PR validates the commit `fix(commits): accept ! breaking-change marker in subject` (which itself does not use `!`, so this PR can land cleanly under the old regex)

## Compatibility

Pure loosening — every previously-accepted subject is still accepted. No caller changes required.