### PR TITLE
fix(commits): skip default git revert messages

### DIFF
--- a/.github/workflows/reusable-conventional-commits.yml
+++ b/.github/workflows/reusable-conventional-commits.yml
@@ -41,8 +41,8 @@ jobs:
                       HASH=$(echo "$line" | cut -d' ' -f1)
                       MSG=$(echo "$line" | cut -d' ' -f2-)
 
-                      # Skip merge commits
-                      if [[ "$MSG" == Merge* ]]; then
+                      # Skip messages git itself generates (merges, reverts).
+                      if [[ "$MSG" == Merge* || "$MSG" == Revert\ \"* ]]; then
                           continue
                       fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.2] - 2026-05-02
+
+### Fixed
+
+- `reusable-conventional-commits.yml` — skip the default message that `git revert` generates
+  (`Revert "<original subject>"`) the same way merge commits are skipped. Previously the
+  validator rejected reverts and forced contributors to hand-edit the message into the
+  conventional schema, which dropped the `Revert "` prefix that release-please and similar
+  tools rely on to group reverts. Hand-written `revert: …` / `revert(scope): …` subjects are
+  still validated against `allowed-types`. (#33)
+
 ## [0.6.1] - 2026-05-01
 
 ### Fixed


### PR DESCRIPTION
## Summary

- Extends the merge-commit skip in `reusable-conventional-commits.yml` to also bypass the default message that `git revert` generates (`Revert "<original subject>"`).
- Hand-written `revert: …` / `revert(scope): …` subjects still go through `allowed-types` validation — only the auto-generated form is bypassed.
- Adds CHANGELOG entry for 0.6.2.

Fixes #33.

## Test plan

- [ ] PR validation passes on this PR (the fix doesn't change behaviour for non-revert commits)
- [ ] Verify locally that a `Revert "feat(foo): add bar"` style subject would now be skipped by the bash matcher