### PR TITLE
0.7.0: stale defaults, release-token, composer pin

### DIFF
--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -55,6 +55,7 @@ jobs:
               with:
                   php-version: ${{ matrix.php }}
                   coverage: ${{ matrix.php == inputs.php-version-coverage && 'pcov' || 'none' }}
+                  tools: composer:^2.9.8
 
             - uses: actions/cache@v4
               with:
@@ -87,6 +88,7 @@ jobs:
               with:
                   php-version: ${{ inputs.php-version-coverage }}
                   coverage: none
+                  tools: composer:^2.9.8
 
             - uses: actions/cache@v4
               with:
@@ -108,6 +110,7 @@ jobs:
               with:
                   php-version: ${{ inputs.php-version-coverage }}
                   coverage: none
+                  tools: composer:^2.9.8
 
             - uses: actions/cache@v4
               with:

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -8,6 +8,16 @@ on:
                 required: false
                 type: string
                 default: 'CHANGELOG.md'
+        secrets:
+            release-token:
+                description: |
+                    Token used to push tags, create the release, and comment on
+                    the merged PR. Defaults to GITHUB_TOKEN; pass a PAT or
+                    GitHub App installation token when downstream `release` /
+                    `push: tags` workflows on the calling repo need to fire on
+                    the created release (GITHUB_TOKEN loop-prevention
+                    suppresses them otherwise).
+                required: false
 
 jobs:
     release:
@@ -59,7 +69,7 @@ jobs:
                       gh release delete "$tag" --yes --cleanup-tag || true
                   done
               env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GH_TOKEN: ${{ secrets.release-token || secrets.GITHUB_TOKEN }}
 
             - name: Create release
               if: steps.version.outputs.skip == 'false'
@@ -74,12 +84,13 @@ jobs:
                       --generate-notes \
                       $PRERELEASE_FLAG
               env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GH_TOKEN: ${{ secrets.release-token || secrets.GITHUB_TOKEN }}
 
             - name: Comment on merged PR
               if: steps.version.outputs.skip == 'false'
               uses: actions/github-script@v7
               with:
+                  github-token: ${{ secrets.release-token || secrets.GITHUB_TOKEN }}
                   script: |
                       const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
                           owner: context.repo.owner,

--- a/.github/workflows/reusable-stale.yml
+++ b/.github/workflows/reusable-stale.yml
@@ -7,27 +7,27 @@ on:
                 description: 'Days of inactivity before marking an issue as stale'
                 required: false
                 type: number
-                default: 30
+                default: 60
             days-before-issue-close:
                 description: 'Days after stale before closing an issue'
                 required: false
                 type: number
-                default: 14
+                default: 30
             days-before-pr-stale:
                 description: 'Days of inactivity before marking a PR as stale'
                 required: false
                 type: number
-                default: 60
+                default: 30
             days-before-pr-close:
                 description: 'Days after stale before closing a PR'
                 required: false
                 type: number
-                default: 21
+                default: 30
             exempt-labels:
                 description: 'Comma-separated exempt labels'
                 required: false
                 type: string
-                default: 'pinned,security,in-progress'
+                default: 'pinned,security,in-progress,approved,refined,keep'
 
 jobs:
     stale:

--- a/.github/workflows/reusable-wp-e2e.yml
+++ b/.github/workflows/reusable-wp-e2e.yml
@@ -69,6 +69,7 @@ jobs:
               with:
                   php-version: '8.4'
                   coverage: none
+                  tools: composer:^2.9.8
 
             - name: Install Composer dependencies
               if: hashFiles('composer.json') != ''

--- a/.github/workflows/reusable-wp-integration.yml
+++ b/.github/workflows/reusable-wp-integration.yml
@@ -87,6 +87,7 @@ jobs:
                   php-version: ${{ matrix.php }}
                   extensions: mysqli, intl, mbstring
                   coverage: ${{ matrix.php == inputs.php-version-coverage && 'pcov' || 'none' }}
+                  tools: composer:^2.9.8
 
             - uses: actions/cache@v4
               with:

--- a/.github/workflows/reusable-wp-theme-ci.yml
+++ b/.github/workflows/reusable-wp-theme-ci.yml
@@ -108,6 +108,7 @@ jobs:
               with:
                   php-version: ${{ inputs.php-version }}
                   coverage: none
+                  tools: composer:^2.9.8
 
             - uses: actions/cache@v4
               with:

--- a/.github/workflows/reusable-wp-visual-regression.yml
+++ b/.github/workflows/reusable-wp-visual-regression.yml
@@ -86,6 +86,7 @@ jobs:
               with:
                   php-version: '8.4'
                   coverage: none
+                  tools: composer:^2.9.8
 
             - name: Install Composer dependencies
               if: hashFiles('composer.json') != ''

--- a/.github/workflows/reusable-wporg-deploy.yml
+++ b/.github/workflows/reusable-wporg-deploy.yml
@@ -45,6 +45,7 @@ jobs:
               with:
                   php-version: '8.4'
                   coverage: none
+                  tools: composer:^2.9.8
 
             - name: Install production dependencies
               run: composer install --no-dev --no-interaction --prefer-dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,43 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] - 2026-05-24
+
+### Added
+
+- `reusable-release.yml` — optional `release-token` secret. Defaults to
+  `GITHUB_TOKEN`; pass a PAT or GitHub App installation token so downstream
+  `release` / `push: tags` workflows on the calling repo fire on the created
+  release (GitHub's `GITHUB_TOKEN` loop-prevention suppresses them otherwise).
+  Backwards-compatible — callers that don't pass the secret are unaffected. (#35)
+
+### Changed
+
+- `reusable-stale.yml` — rebalance default day thresholds and broaden exempt labels.
+  - Issues now go stale after 60 days (was 30) and close 30 days later (was 14)
+    — total 90-day idle window before closure (was 44).
+  - PRs go stale faster (30 days, was 60) but get a longer grace period before
+    closing (30 days, was 21) — total 60-day window before closure (was 81).
+    Shifts the bias from "let PRs linger forever" to "ping authors sooner, then
+    give them a full month to respond".
+  - `exempt-labels` default extended with `approved`, `refined`, `keep` so
+    triaged items don't get culled.
+
+  All four day-count inputs and the `exempt-labels` input remain overridable
+  per-repo via `with:` if a project needs different settings.
+
+### Security
+
+- `reusable-ci.yml`, `reusable-wp-e2e.yml`, `reusable-wp-integration.yml`,
+  `reusable-wp-theme-ci.yml`, `reusable-wp-visual-regression.yml`,
+  `reusable-wporg-deploy.yml` — pin `tools: composer:^2.9.8` on every
+  `shivammathur/setup-php@v2` step. Defends against future regressions of
+  [GHSA-f9f8-rm49-7jv2](https://github.com/advisories/GHSA-f9f8-rm49-7jv2)
+  (Composer ≤ 2.9.7 leaked GitHub Actions tokens to stderr when validating
+  new-format tokens containing hyphens). No functional change today —
+  `setup-php@v2` already installs latest stable Composer; the pin makes the
+  minimum explicit. (#36)
+
 ## [0.6.2] - 2026-05-02
 
 ### Fixed
@@ -148,3 +185,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - WP integration workflow uses `wp-phpunit/wp-phpunit` Composer package instead of SVN checkout
 - Upgrade `actions/stale` from v9 to v10
+
+[0.7.0]: https://github.com/apermo/reusable-workflows/compare/v0.6.2...v0.7.0

--- a/README.md
+++ b/README.md
@@ -220,6 +220,10 @@ CHANGELOG-driven release automation. Extracts version from CHANGELOG.md, creates
 |-------|------|---------|-------------|
 | `changelog-path` | string | `CHANGELOG.md` | Path to changelog |
 
+| Secret | Required | Description |
+|--------|----------|-------------|
+| `release-token` | No | Override for `GITHUB_TOKEN`. Pass a PAT or GitHub App installation token when downstream `release` / `push: tags` workflows on the calling repo need to fire on the created release (GitHub's `GITHUB_TOKEN` loop-prevention suppresses them otherwise). |
+
 ```yaml
 jobs:
   release:
@@ -275,11 +279,11 @@ Auto-closes stale issues and PRs.
 
 | Input | Type | Default | Description |
 |-------|------|---------|-------------|
-| `days-before-issue-stale` | number | `30` | Days of inactivity before marking an issue as stale |
-| `days-before-issue-close` | number | `14` | Days after stale before closing an issue |
-| `days-before-pr-stale` | number | `60` | Days of inactivity before marking a PR as stale |
-| `days-before-pr-close` | number | `21` | Days after stale before closing a PR |
-| `exempt-labels` | string | `pinned,security,in-progress` | Exempt labels |
+| `days-before-issue-stale` | number | `60` | Days of inactivity before marking an issue as stale |
+| `days-before-issue-close` | number | `30` | Days after stale before closing an issue |
+| `days-before-pr-stale` | number | `30` | Days of inactivity before marking a PR as stale |
+| `days-before-pr-close` | number | `30` | Days after stale before closing a PR |
+| `exempt-labels` | string | `pinned,security,in-progress,approved,refined,keep` | Exempt labels |
 
 ```yaml
 jobs:


### PR DESCRIPTION
## Summary

Three small changes bundled into 0.7.0. Consumers pinned to `@main`
(`apermo/template-wordpress` + the 13 derived plugin/theme repos) inherit
everything immediately on merge — no per-repo follow-up PRs needed.

### `reusable-stale.yml` — rebalance defaults (the MINOR-bump driver)

| Input                    | Old                             | New                                                |
|--------------------------|---------------------------------|----------------------------------------------------|
| days-before-issue-stale  | 30                              | 60                                                 |
| days-before-issue-close  | 14                              | 30                                                 |
| days-before-pr-stale     | 60                              | 30                                                 |
| days-before-pr-close     | 21                              | 30                                                 |
| exempt-labels            | pinned,security,in-progress     | pinned,security,in-progress,approved,refined,keep  |

Issues: 44d → 90d total idle window. PRs: 81d → 60d total, with the bias
shifted from "let PRs linger forever" to "ping authors sooner, then give
them a full month to respond". `approved`, `refined`, `keep` added so
triaged items stop getting culled.

Consumers that already pass these inputs via `with:` are unaffected.

### `reusable-release.yml` — optional `release-token` secret (#35)

Adds an optional `release-token` secret. Defaults to `GITHUB_TOKEN`, so
every existing caller behaves identically. Repos that need downstream
`release` / `push: tags` workflows to fire on the created release can
pass a PAT or GitHub App installation token — this breaks GitHub's
`GITHUB_TOKEN` loop-prevention.

Three sites switched to `${{ secrets.release-token || secrets.GITHUB_TOKEN }}`:
`gh release delete`, `gh release create`, and the github-script PR-comment
step (now via an explicit `github-token:` input).

### setup-php Composer pin — `tools: composer:^2.9.8` (#36)

Pins a minimum Composer on every `shivammathur/setup-php@v2` step across
six workflows. Defends against future regressions of
[GHSA-f9f8-rm49-7jv2](https://github.com/advisories/GHSA-f9f8-rm49-7jv2)
(Composer ≤ 2.9.7 leaked Actions tokens to stderr when validating
new-format tokens containing hyphens).

Non-functional today — `setup-php@v2` already installs the latest stable
Composer; the pin makes the floor explicit. Affected files: `reusable-ci`,
`reusable-wp-e2e`, `reusable-wp-integration`, `reusable-wp-theme-ci`,
`reusable-wp-visual-regression`, `reusable-wporg-deploy` (8 setup-php
blocks total).

The audit-Actions-logs task in #36 is unrelated to this PR and stays on
the issue.

Closes #35.
Partially addresses #36 (hardening half; audit task remains).

## Test plan

- [ ] `pr-validation` job green (CHANGELOG 0.7.0 entry parses; no existing tag)
- [ ] `conventional-commits` job green (4 atomic commits, 50/72 char limits)
- [ ] `actionlint` reviewdog stays clean on touched lines (pre-existing SC2129/SC2016 warnings live on lines this PR doesn't touch)
- [ ] Self-referencing reusable CI on this repo stays green