### PR TITLE
feat(pr-validation): decouple merge from release

### DIFF
--- a/.github/workflows/reusable-pr-validation.yml
+++ b/.github/workflows/reusable-pr-validation.yml
@@ -24,18 +24,49 @@ jobs:
             - name: Extract version from CHANGELOG
               id: version
               run: |
-                  VERSION=$(grep -m1 -oP '(?<=## \[)\d+\.\d+\.\d+[^]]*' ${{ inputs.changelog-path }} || echo "")
+                  CHANGELOG="${{ inputs.changelog-path }}"
 
-                  if [ -z "$VERSION" ]; then
+                  # Phase 1: first "## [ ... ]" heading whose label is not "Unreleased".
+                  HEADING=$(grep -oP '^##\s+\[\K[^\]]+\](.*)$' "$CHANGELOG" \
+                      | grep -viP '^Unreleased\]' | head -n1 || true)
+
+                  if [ -z "$HEADING" ]; then
                       echo "result=no_version" >> "$GITHUB_OUTPUT"
-                      echo "::error::No version found in ${{ inputs.changelog-path }}"
+                      echo "No release version heading found — merge without release."
+                      exit 0
+                  fi
+
+                  VERSION="${HEADING%%]*}"
+                  REST="${HEADING#*]}"
+
+                  # A heading with no digit is prose, not a botched release.
+                  if ! printf '%s' "$VERSION" | grep -qP '[0-9]'; then
+                      echo "result=no_version" >> "$GITHUB_OUTPUT"
+                      echo "Top heading '[$VERSION]' is not a version — merge without release."
+                      exit 0
+                  fi
+
+                  # Phase 2: strict SemVer 2.0.0 + Keep-a-Changelog date.
+                  SEMVER='^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'
+                  DATE_RE='^[[:space:]]*-[[:space:]]+[0-9]{4}-[0-9]{2}-[0-9]{2}'
+
+                  if ! printf '%s' "$VERSION" | grep -qP "$SEMVER"; then
+                      echo "result=malformed" >> "$GITHUB_OUTPUT"
+                      echo "::error::Malformed version heading '[$VERSION]' in $CHANGELOG — expected '## [X.Y.Z] - YYYY-MM-DD' (SemVer)."
+                      exit 1
+                  fi
+
+                  if ! printf '%s' "$REST" | grep -qP "$DATE_RE"; then
+                      echo "result=malformed" >> "$GITHUB_OUTPUT"
+                      echo "::error::Version heading '[$VERSION]' in $CHANGELOG is missing a valid ' - YYYY-MM-DD' date."
                       exit 1
                   fi
 
                   if git tag -l "v$VERSION" | grep -q .; then
+                      echo "pr_version=$VERSION" >> "$GITHUB_OUTPUT"
                       echo "result=already_released" >> "$GITHUB_OUTPUT"
-                      echo "::error::Version $VERSION already has a git tag (v$VERSION) — add a new unreleased entry to ${{ inputs.changelog-path }}"
-                      exit 1
+                      echo "v$VERSION already tagged — merge without release."
+                      exit 0
                   fi
 
                   echo "pr_version=$VERSION" >> "$GITHUB_OUTPUT"
@@ -47,7 +78,7 @@ jobs:
                   fi
 
                   echo "result=ok" >> "$GITHUB_OUTPUT"
-                  echo "Version: $VERSION"
+                  echo "Version: $VERSION (new release)"
 
             - name: Check CHANGELOG entry
               if: steps.version.outputs.prerelease == 'false'
@@ -60,8 +91,8 @@ jobs:
                       echo "::warning::CHANGELOG section for $VERSION appears empty"
                   fi
 
-            - name: Comment on failure
-              if: failure()
+            - name: Comment on malformed CHANGELOG
+              if: failure() && steps.version.outputs.result == 'malformed'
               uses: actions/github-script@v7
               with:
                   script: |
@@ -69,5 +100,5 @@ jobs:
                           issue_number: context.issue.number,
                           owner: context.repo.owner,
                           repo: context.repo.repo,
-                          body: 'CHANGELOG validation failed. Please ensure ${{ inputs.changelog-path }} contains a valid version heading (`## [X.Y.Z] - YYYY-MM-DD`).'
+                          body: 'CHANGELOG validation failed: malformed version heading in `${{ inputs.changelog-path }}`. Use `## [X.Y.Z] - YYYY-MM-DD` (Semantic Versioning), or `## [Unreleased]` if no release is intended.'
                       })

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] - 2026-06-07
+
+### Changed
+
+- `reusable-pr-validation.yml` — decouple merging from releasing. A missing,
+  `## [Unreleased]`, or already-tagged top heading now **passes** (merge without
+  release) instead of hard-failing; only a malformed version heading (looks like a
+  version but isn't valid SemVer, or missing the ` - YYYY-MM-DD` date) fails. A new
+  untagged `## [X.Y.Z] - YYYY-MM-DD` still triggers a release on merge.
+  `reusable-release.yml` is unchanged — its existing tag-existence skip already gates
+  releases on a version bump. (#39)
+
 ## [0.7.0] - 2026-05-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -232,7 +232,15 @@ jobs:
 
 ### `reusable-pr-validation.yml`
 
-Validates CHANGELOG entries on pull requests.
+Validates the top `CHANGELOG.md` version heading on pull requests. Merging is decoupled
+from releasing: a PR only needs a valid heading when it intends to release.
+
+| Top heading | Result | Behavior |
+|-------------|--------|----------|
+| Missing, `## [Unreleased]`, or non-version label | `no_version` | **Passes** — merge without release |
+| Valid `## [X.Y.Z] - YYYY-MM-DD`, already tagged | `already_released` | **Passes** — merge without release |
+| Valid `## [X.Y.Z] - YYYY-MM-DD`, untagged | `ok` | **Passes** — releases on merge |
+| Looks like a version but isn't valid SemVer / missing date | `malformed` | **Fails** |
 
 | Input | Type | Default | Description |
 |-------|------|---------|-------------|
@@ -243,6 +251,10 @@ jobs:
   pr-validation:
     uses: apermo/reusable-workflows/.github/workflows/reusable-pr-validation.yml@main
 ```
+
+**Migration note:** PRs without a version bump now merge without releasing. Add a new
+`## [X.Y.Z] - YYYY-MM-DD` heading to cut a release on merge; the only hard failure is a
+malformed version heading.
 
 ### `reusable-conventional-commits.yml`
 


### PR DESCRIPTION
Closes #39.

## Problem

`reusable-pr-validation.yml` hard-fails (`exit 1`) when the top `CHANGELOG.md`
heading isn't a never-tagged semver, forcing **one release per merge** — you
can't land a PR without bumping the version. Surfaced downstream in
apermo/wapuu-tracker#19 / #20.

## Approach (Option B from the issue)

Single behavioral change in `reusable-pr-validation.yml`. The old one-shot
regex collapsed three distinct cases into "empty version"; it's replaced with a
two-phase **classify-the-heading** scheme:

1. Find the first `## [...]` heading whose label isn't `Unreleased`.
2. Validate it against strict SemVer 2.0.0 + the Keep-a-Changelog ` - YYYY-MM-DD` date.

| Top heading | Result | Behavior |
|-------------|--------|----------|
| Missing / `## [Unreleased]` / non-version label | `no_version` | **Pass** — merge, no release |
| Valid `## [X.Y.Z] - YYYY-MM-DD`, already tagged | `already_released` | **Pass** — merge, no release |
| Valid `## [X.Y.Z] - YYYY-MM-DD`, untagged | `ok` | **Pass** — releases on merge |
| Looks like a version but isn't valid SemVer / no date | `malformed` | **Fail** |

The failure-comment step is scoped to `result == 'malformed'` so it only fires
on a genuine malformed heading.

## Why `reusable-release.yml` is unchanged

It already `exit 0`s (skips) when no version is found or the tag exists. A bump
is the only thing that introduces a new untagged top version, so its existing
tag-existence check **is** the release-on-bump gate. A CHANGELOG-diff gate would
be strictly less reliable under squash/force-push, so it's deliberately omitted.

## Verification

- `actionlint` passes on the edited workflow.
- Classification logic spot-checked against 9 sample headings (incl. `Unreleased`
  above a real version, prerelease, build metadata, `[1.2]`, `[v1.0.0]`, missing
  date) — all classify as expected.
- This PR adds `## [0.8.0]` → `result=ok` → self-referencing CI (`pr-validation.yml`
  calling the reusable file by relative path) is the live integration test.
- Regression test post-merge: a docs-only PR with no bump should merge green and
  produce no release.

## Notes for consumers

Migration note added to the README: PRs without a version bump now merge without
releasing; add a new `## [X.Y.Z] - YYYY-MM-DD` heading to cut a release.

Option A (release-please wrapper) from the issue is intentionally out of scope and
can follow as a separate effort for new repos.