### PR TITLE
fix: plugin-mode CI gaps for blocks and wp-env

### DIFF
--- a/.github/workflows/reusable-plugin-check.yml
+++ b/.github/workflows/reusable-plugin-check.yml
@@ -69,6 +69,25 @@ jobs:
         steps:
             - uses: actions/checkout@v4
 
+            # plugin-check-action provisions its own wp-env (plugin-check plugin,
+            # port mapping, plugin slug) only when no .wp-env.json is present. A repo
+            # one (required by reusable-wp-e2e.yml) makes the action skip its setup and
+            # then die on "Environment not initialized". Move it aside for the run.
+            - name: Hide repo wp-env config
+              id: hide-wp-env
+              run: |
+                  moved=
+                  for f in .wp-env.json .wp-env.override.json; do
+                      if [ -f "$f" ]; then
+                          mv "$f" "$f.plugin-check-bak"
+                          moved="$moved $f"
+                      fi
+                  done
+                  if [ -n "$moved" ]; then
+                      echo "::notice::Moved repo wp-env config aside for plugin-check:$moved"
+                      echo "moved=true" >> "$GITHUB_OUTPUT"
+                  fi
+
             - uses: wordpress/plugin-check-action@v1
               with:
                   repo-token: ${{ github.token }}
@@ -83,3 +102,12 @@ jobs:
                   ignore-warnings: ${{ inputs.ignore-warnings }}
                   ignore-errors: ${{ inputs.ignore-errors }}
                   include-experimental: ${{ inputs.include-experimental }}
+
+            - name: Restore repo wp-env config
+              if: always() && steps.hide-wp-env.outputs.moved == 'true'
+              run: |
+                  for f in .wp-env.json .wp-env.override.json; do
+                      if [ -f "$f.plugin-check-bak" ]; then
+                          mv "$f.plugin-check-bak" "$f"
+                      fi
+                  done

--- a/.github/workflows/reusable-wp-e2e.yml
+++ b/.github/workflows/reusable-wp-e2e.yml
@@ -28,6 +28,11 @@ on:
                 required: false
                 type: boolean
                 default: false
+            build-command:
+                description: 'npm script that compiles assets/blocks before wp-env starts (skipped if the script is absent)'
+                required: false
+                type: string
+                default: 'build'
 
 permissions:
     contents: read
@@ -91,6 +96,17 @@ jobs:
             - name: Install @axe-core/playwright
               if: inputs.a11y
               run: npm install --no-save @axe-core/playwright
+
+            # Compile Gutenberg blocks / assets so they exist in the live-mounted
+            # plugin before wp-env starts. Skipped when the script is absent so
+            # plugins/themes without a build step are unaffected.
+            - name: Build assets
+              run: |
+                  if jq -e --arg s "${{ inputs.build-command }}" '.scripts[$s]' package.json >/dev/null 2>&1; then
+                      npm run "${{ inputs.build-command }}"
+                  else
+                      echo "No '${{ inputs.build-command }}' npm script; skipping asset build."
+                  fi
 
             - name: Install wp-env
               run: npm install -g @wordpress/env

--- a/.github/workflows/reusable-wp-e2e.yml
+++ b/.github/workflows/reusable-wp-e2e.yml
@@ -101,11 +101,13 @@ jobs:
             # plugin before wp-env starts. Skipped when the script is absent so
             # plugins/themes without a build step are unaffected.
             - name: Build assets
+              env:
+                  BUILD_COMMAND: ${{ inputs.build-command }}
               run: |
-                  if jq -e --arg s "${{ inputs.build-command }}" '.scripts[$s]' package.json >/dev/null 2>&1; then
-                      npm run "${{ inputs.build-command }}"
+                  if jq -e --arg s "$BUILD_COMMAND" '.scripts[$s]' package.json >/dev/null 2>&1; then
+                      npm run "$BUILD_COMMAND"
                   else
-                      echo "No '${{ inputs.build-command }}' npm script; skipping asset build."
+                      echo "No '$BUILD_COMMAND' npm script; skipping asset build."
                   fi
 
             - name: Install wp-env

--- a/.github/workflows/reusable-wporg-deploy.yml
+++ b/.github/workflows/reusable-wporg-deploy.yml
@@ -64,23 +64,25 @@ jobs:
               if: hashFiles('package.json') != ''
               with:
                   node-version: ${{ inputs.node-version }}
-                  cache: npm
+                  cache: ${{ hashFiles('package-lock.json') != '' && 'npm' || '' }}
 
             # Compile Gutenberg blocks / assets so the deployed plugin ships a
             # populated build/ dir. Skipped when there is no package.json or the
             # script is absent so non-JS plugins/themes are unaffected.
             - name: Build assets
               if: hashFiles('package.json') != ''
+              env:
+                  BUILD_COMMAND: ${{ inputs.build-command }}
               run: |
                   if [ -f package-lock.json ]; then
                       npm ci
                   else
                       npm install
                   fi
-                  if jq -e --arg s "${{ inputs.build-command }}" '.scripts[$s]' package.json >/dev/null 2>&1; then
-                      npm run "${{ inputs.build-command }}"
+                  if jq -e --arg s "$BUILD_COMMAND" '.scripts[$s]' package.json >/dev/null 2>&1; then
+                      npm run "$BUILD_COMMAND"
                   else
-                      echo "No '${{ inputs.build-command }}' npm script; skipping asset build."
+                      echo "No '$BUILD_COMMAND' npm script; skipping asset build."
                   fi
 
             - name: Deploy to WordPress.org

--- a/.github/workflows/reusable-wporg-deploy.yml
+++ b/.github/workflows/reusable-wporg-deploy.yml
@@ -16,6 +16,16 @@ on:
                 description: 'Path to build directory (false to skip build copy)'
                 required: false
                 type: string
+            node-version:
+                description: 'Node.js version for the asset build'
+                required: false
+                type: string
+                default: '22'
+            build-command:
+                description: 'npm script that compiles assets/blocks before deploy (skipped if package.json or the script is absent)'
+                required: false
+                type: string
+                default: 'build'
             generate-zip:
                 description: 'Generate a zip file as build artifact'
                 required: false
@@ -49,6 +59,29 @@ jobs:
 
             - name: Install production dependencies
               run: composer install --no-dev --no-interaction --prefer-dist
+
+            - uses: actions/setup-node@v4
+              if: hashFiles('package.json') != ''
+              with:
+                  node-version: ${{ inputs.node-version }}
+                  cache: npm
+
+            # Compile Gutenberg blocks / assets so the deployed plugin ships a
+            # populated build/ dir. Skipped when there is no package.json or the
+            # script is absent so non-JS plugins/themes are unaffected.
+            - name: Build assets
+              if: hashFiles('package.json') != ''
+              run: |
+                  if [ -f package-lock.json ]; then
+                      npm ci
+                  else
+                      npm install
+                  fi
+                  if jq -e --arg s "${{ inputs.build-command }}" '.scripts[$s]' package.json >/dev/null 2>&1; then
+                      npm run "${{ inputs.build-command }}"
+                  else
+                      echo "No '${{ inputs.build-command }}' npm script; skipping asset build."
+                  fi
 
             - name: Deploy to WordPress.org
               uses: 10up/action-wordpress-plugin-deploy@stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2026-06-07
+
+### Added
+
+- `reusable-wp-e2e.yml` — `build-command` input (default `build`). Compiles
+  Gutenberg blocks/assets via `npm run <build-command>` after `npm ci` and before
+  wp-env starts, so block E2E specs see compiled blocks. Skipped when the named
+  npm script is absent, so non-block plugins/themes are unaffected. (#44)
+- `reusable-wporg-deploy.yml` — `node-version` (default `22`) and `build-command`
+  (default `build`) inputs. Runs `npm ci && npm run <build-command>` before deploy
+  so the shipped plugin includes a compiled `build/`. Skipped when there is no
+  `package.json` or the named script is absent. (#44)
+
+### Fixed
+
+- `reusable-plugin-check.yml` — no longer fails on repos that commit a `.wp-env.json`
+  (required by `reusable-wp-e2e.yml`). `plugin-check-action` only provisions its own
+  wp-env when none exists; a repo one made it skip setup and die with "Environment not
+  initialized". The repo `.wp-env.json`/`.wp-env.override.json` are now moved aside for
+  the run and restored afterwards. (#44)
+
 ## [0.8.0] - 2026-06-07
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -166,8 +166,8 @@ WordPress [Plugin Check](https://wordpress.org/plugins/plugin-check/) runner. Wr
 [`wordpress/plugin-check-action@v1`](https://github.com/WordPress/plugin-check-action) and reports guideline
 violations as GitHub file annotations. Intended for plugins targeting the wordpress.org plugin directory.
 
-A repo-provided `.wp-env.json` (required by `reusable-wp-e2e.yml`) is moved aside for the run and restored
-afterwards, so `plugin-check-action` provisions its own environment instead of failing on it.
+A repo-provided `.wp-env.json` or `.wp-env.override.json` (required by `reusable-wp-e2e.yml`) is moved aside for
+the run and restored afterwards, so `plugin-check-action` provisions its own environment instead of failing on it.
 
 | Input | Type | Default | Description |
 |-------|------|---------|-------------|
@@ -189,6 +189,39 @@ jobs:
     uses: apermo/reusable-workflows/.github/workflows/reusable-plugin-check.yml@main
     with:
       wp-version: latest
+```
+
+### `reusable-wporg-deploy.yml`
+
+Deploys a plugin or theme to the WordPress.org SVN repository. Wraps
+[`10up/action-wordpress-plugin-deploy`](https://github.com/10up/action-wordpress-plugin-deploy). When a
+`package.json` is present it runs `npm ci && npm run <build-command>` before deploy, so block-based plugins ship a
+compiled `build/`. The build step is skipped when there is no `package.json` or the named npm script is absent.
+
+| Input | Type | Default | Description |
+|-------|------|---------|-------------|
+| `slug` | string | repo name | WordPress.org plugin/theme slug |
+| `assets-dir` | string | `".wordpress-org"` | Path to WordPress.org assets (banners, icons, screenshots) |
+| `build-dir` | string | `""` | Path to build directory (`false` to skip build copy) |
+| `node-version` | string | `"22"` | Node.js version for the asset build |
+| `build-command` | string | `"build"` | npm script that compiles assets/blocks before deploy (skipped if absent) |
+| `generate-zip` | boolean | `false` | Generate a zip file as build artifact |
+| `dry-run` | boolean | `false` | Run without committing to SVN |
+
+| Secret | Required | Description |
+|--------|----------|-------------|
+| `svn-username` | Yes | WordPress.org SVN username |
+| `svn-password` | Yes | WordPress.org SVN password |
+
+```yaml
+jobs:
+  deploy:
+    uses: apermo/reusable-workflows/.github/workflows/reusable-wporg-deploy.yml@main
+    with:
+      slug: my-plugin
+    secrets:
+      svn-username: ${{ secrets.WPORG_SVN_USERNAME }}
+      svn-password: ${{ secrets.WPORG_SVN_PASSWORD }}
 ```
 
 ### `reusable-ci.yml`

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ plugin in the current directory:
 | `multisite` | string | `"none"` | `"none"`, `"both"`, or `"only"` |
 | `mailpit` | boolean | `false` | Run Mailpit mail catcher (SMTP `:1025`, API `:8025`) |
 | `a11y` | boolean | `false` | Install `@axe-core/playwright` for accessibility testing |
+| `build-command` | string | `"build"` | npm script that compiles assets/blocks before wp-env starts (skipped if absent) |
+
+Block-based plugins/themes are built before wp-env starts (default `npm run build`) so compiled blocks
+are present when specs run. The step is skipped when no matching npm script exists.
 
 Recommended `wp-versions` setup: test against `"latest"` and the minimum supported WP version (e.g. `'["latest", "6.4"]'`).
 
@@ -161,6 +165,9 @@ jobs:
 WordPress [Plugin Check](https://wordpress.org/plugins/plugin-check/) runner. Wraps
 [`wordpress/plugin-check-action@v1`](https://github.com/WordPress/plugin-check-action) and reports guideline
 violations as GitHub file annotations. Intended for plugins targeting the wordpress.org plugin directory.
+
+A repo-provided `.wp-env.json` (required by `reusable-wp-e2e.yml`) is moved aside for the run and restored
+afterwards, so `plugin-check-action` provisions its own environment instead of failing on it.
 
 | Input | Type | Default | Description |
 |-------|------|---------|-------------|


### PR DESCRIPTION
Closes #44.

Two plugin-mode CI gaps surfaced on the first derived plugin repo
(apermo/wapuu-tracker). Both are addressed here.

## 1. `reusable-plugin-check.yml` vs a repo `.wp-env.json`

`reusable-wp-e2e.yml` hard-requires a committed `.wp-env.json`, but
`plugin-check-action` only provisions its own wp-env (plugin-check
plugin, port mapping, plugin slug) **when none exists** — with a repo
one it skips setup and dies on `Environment not initialized`. The two
reusables had contradictory requirements; a plugin repo couldn't pass
both.

**Fix:** move the repo `.wp-env.json` / `.wp-env.override.json` aside
for the action's run (then restore), so the action provisions its own
correct environment.

## 2. Gutenberg blocks were never compiled

- `reusable-wp-e2e.yml` ran `npm ci` but never `npm run build` → block
  specs would fail (blocks absent in wp-env).
- `reusable-wporg-deploy.yml` ran Composer only → deployed plugin
  shipped without a compiled `build/`.

**Fix:** add a `build-command` input (default `build`) to both.
- E2E builds assets after `npm ci` and **before wp-env starts**.
- Deploy runs `npm ci && npm run <build-command>` **before** the 10up
  action (also adds a `node-version` input).

Both build steps skip cleanly when the named npm script (or, for
deploy, `package.json`) is absent, so non-block plugins/themes and
existing callers are unaffected.

## Acceptance criteria
- [x] A plugin repo with a `.wp-env.json` passes both E2E and Plugin Check.
- [x] E2E builds blocks before starting wp-env.
- [x] WP.org deploy ships a `build/` produced by `npm run build`.

## Notes
- New inputs are optional with defaults — backwards-compatible.
- `actionlint` passes on all three modified workflows (the pre-existing
  SC2016 info in the Mailpit `wp eval` script is unchanged).