### PR TITLE
ci: bump actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -16,5 +16,5 @@ jobs:
         name: Lint workflows
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
             - uses: reviewdog/action-actionlint@v1

--- a/.github/workflows/reusable-ci.yml
+++ b/.github/workflows/reusable-ci.yml
@@ -49,7 +49,7 @@ jobs:
             matrix:
                 php: ${{ fromJson(inputs.php-versions) }}
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
 
             - uses: shivammathur/setup-php@v2
               with:
@@ -57,7 +57,7 @@ jobs:
                   coverage: ${{ matrix.php == inputs.php-version-coverage && 'pcov' || 'none' }}
                   tools: composer:^2.9.8
 
-            - uses: actions/cache@v4
+            - uses: actions/cache@v5
               with:
                   path: vendor
                   key: composer-${{ matrix.php }}-${{ hashFiles('composer.lock') }}
@@ -82,7 +82,7 @@ jobs:
         if: inputs.run-phpstan
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
 
             - uses: shivammathur/setup-php@v2
               with:
@@ -90,7 +90,7 @@ jobs:
                   coverage: none
                   tools: composer:^2.9.8
 
-            - uses: actions/cache@v4
+            - uses: actions/cache@v5
               with:
                   path: vendor
                   key: composer-${{ inputs.php-version-coverage }}-${{ hashFiles('composer.lock') }}
@@ -104,7 +104,7 @@ jobs:
         if: inputs.run-phpcs
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
 
             - uses: shivammathur/setup-php@v2
               with:
@@ -112,7 +112,7 @@ jobs:
                   coverage: none
                   tools: composer:^2.9.8
 
-            - uses: actions/cache@v4
+            - uses: actions/cache@v5
               with:
                   path: vendor
                   key: composer-${{ inputs.php-version-coverage }}-${{ hashFiles('composer.lock') }}

--- a/.github/workflows/reusable-conventional-commits.yml
+++ b/.github/workflows/reusable-conventional-commits.yml
@@ -18,7 +18,7 @@ jobs:
     validate:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
               with:
                   fetch-depth: 0
 

--- a/.github/workflows/reusable-lhci.yml
+++ b/.github/workflows/reusable-lhci.yml
@@ -62,9 +62,9 @@ jobs:
         name: Lighthouse CI
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
 
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v5
               with:
                   node-version: ${{ inputs.node-version }}
                   cache: ${{ inputs.setup-wp-env && 'npm' || '' }}
@@ -152,7 +152,7 @@ jobs:
               env:
                   CONFIG_PATH: ${{ inputs.config-path }}
 
-            - uses: actions/upload-artifact@v4
+            - uses: actions/upload-artifact@v5
               if: always()
               with:
                   name: ${{ inputs.artifact-name }}

--- a/.github/workflows/reusable-plugin-check.yml
+++ b/.github/workflows/reusable-plugin-check.yml
@@ -67,7 +67,7 @@ jobs:
         name: Plugin Check
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
 
             # plugin-check-action provisions its own wp-env (plugin-check plugin,
             # port mapping, plugin slug) only when no .wp-env.json is present. A repo

--- a/.github/workflows/reusable-pr-validation.yml
+++ b/.github/workflows/reusable-pr-validation.yml
@@ -17,7 +17,7 @@ jobs:
             result: ${{ steps.version.outputs.result }}
             prerelease: ${{ steps.version.outputs.prerelease }}
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
               with:
                   fetch-depth: 0
 
@@ -93,7 +93,7 @@ jobs:
 
             - name: Comment on malformed CHANGELOG
               if: failure() && steps.version.outputs.result == 'malformed'
-              uses: actions/github-script@v7
+              uses: actions/github-script@v8
               with:
                   script: |
                       github.rest.issues.createComment({

--- a/.github/workflows/reusable-prerelease.yml
+++ b/.github/workflows/reusable-prerelease.yml
@@ -17,7 +17,7 @@ jobs:
             contents: write
             pull-requests: write
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
               with:
                   fetch-depth: 0
 
@@ -56,7 +56,7 @@ jobs:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
             - name: Comment on associated PR
-              uses: actions/github-script@v7
+              uses: actions/github-script@v8
               with:
                   script: |
                       const branch = context.ref.replace('refs/heads/', '');

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -27,7 +27,7 @@ jobs:
             contents: write
             pull-requests: write
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
               with:
                   fetch-depth: 0
 
@@ -88,7 +88,7 @@ jobs:
 
             - name: Comment on merged PR
               if: steps.version.outputs.skip == 'false'
-              uses: actions/github-script@v7
+              uses: actions/github-script@v8
               with:
                   github-token: ${{ secrets.release-token || secrets.GITHUB_TOKEN }}
                   script: |

--- a/.github/workflows/reusable-wp-e2e.yml
+++ b/.github/workflows/reusable-wp-e2e.yml
@@ -68,7 +68,7 @@ jobs:
                 wp: ${{ fromJson(needs.matrix-prep.outputs.wp-versions) }}
                 multisite: ${{ fromJson(needs.matrix-prep.outputs.multisite) }}
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
 
             - uses: shivammathur/setup-php@v2
               with:
@@ -80,7 +80,7 @@ jobs:
               if: hashFiles('composer.json') != ''
               run: composer install --no-interaction --prefer-dist
 
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v5
               with:
                   node-version: ${{ inputs.node-version }}
                   cache: npm
@@ -183,7 +183,7 @@ jobs:
                   WP_ADMIN_PASSWORD: password
                   MAILPIT_API_URL: ${{ inputs.mailpit && 'http://localhost:8025' || '' }}
 
-            - uses: actions/upload-artifact@v4
+            - uses: actions/upload-artifact@v5
               if: always()
               with:
                   name: playwright-report-wp${{ matrix.wp.input }}${{ matrix.multisite && '-multisite' || '' }}

--- a/.github/workflows/reusable-wp-integration.yml
+++ b/.github/workflows/reusable-wp-integration.yml
@@ -80,7 +80,7 @@ jobs:
                     --health-timeout=5s
                     --health-retries=5
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
 
             - uses: shivammathur/setup-php@v2
               with:
@@ -89,7 +89,7 @@ jobs:
                   coverage: ${{ matrix.php == inputs.php-version-coverage && 'pcov' || 'none' }}
                   tools: composer:^2.9.8
 
-            - uses: actions/cache@v4
+            - uses: actions/cache@v5
               with:
                   path: vendor
                   key: composer-${{ matrix.php }}-${{ hashFiles('composer.lock') }}

--- a/.github/workflows/reusable-wp-theme-ci.yml
+++ b/.github/workflows/reusable-wp-theme-ci.yml
@@ -58,9 +58,9 @@ jobs:
         if: inputs.run-eslint
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
 
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v5
               with:
                   node-version: ${{ inputs.node-version }}
                   cache: npm
@@ -80,9 +80,9 @@ jobs:
         if: inputs.run-stylelint
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
 
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v5
               with:
                   node-version: ${{ inputs.node-version }}
                   cache: npm
@@ -102,7 +102,7 @@ jobs:
         if: inputs.run-version-check
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
 
             - uses: shivammathur/setup-php@v2
               with:
@@ -110,7 +110,7 @@ jobs:
                   coverage: none
                   tools: composer:^2.9.8
 
-            - uses: actions/cache@v4
+            - uses: actions/cache@v5
               with:
                   path: vendor
                   key: composer-${{ inputs.php-version }}-${{ hashFiles('composer.lock') }}

--- a/.github/workflows/reusable-wp-visual-regression.yml
+++ b/.github/workflows/reusable-wp-visual-regression.yml
@@ -78,7 +78,7 @@ jobs:
                 wp: ${{ fromJson(needs.matrix-prep.outputs.wp-versions) }}
                 multisite: ${{ fromJson(needs.matrix-prep.outputs.multisite) }}
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
               with:
                   lfs: true
 
@@ -92,7 +92,7 @@ jobs:
               if: hashFiles('composer.json') != ''
               run: composer install --no-interaction --prefer-dist
 
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v5
               with:
                   node-version: ${{ inputs.node-version }}
                   cache: npm
@@ -187,7 +187,7 @@ jobs:
                   MAILPIT_API_URL: ${{ inputs.mailpit && 'http://localhost:8025' || '' }}
 
             - name: Upload visual diff artifacts
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v5
               if: failure()
               with:
                   name: visual-regression-diffs-wp${{ matrix.wp.input }}${{ matrix.multisite && '-multisite' || '' }}
@@ -195,7 +195,7 @@ jobs:
                   retention-days: 14
 
             - name: Upload updated snapshots
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v5
               if: inputs.update-snapshots
               with:
                   name: updated-snapshots-wp${{ matrix.wp.input }}${{ matrix.multisite && '-multisite' || '' }}
@@ -205,7 +205,7 @@ jobs:
                       **/*-snapshots/
                   retention-days: 7
 
-            - uses: actions/upload-artifact@v4
+            - uses: actions/upload-artifact@v5
               if: always()
               with:
                   name: vrt-report-wp${{ matrix.wp.input }}${{ matrix.multisite && '-multisite' || '' }}

--- a/.github/workflows/reusable-wporg-deploy.yml
+++ b/.github/workflows/reusable-wporg-deploy.yml
@@ -49,7 +49,7 @@ jobs:
         name: Deploy to WordPress.org
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v5
 
             - uses: shivammathur/setup-php@v2
               with:
@@ -60,7 +60,7 @@ jobs:
             - name: Install production dependencies
               run: composer install --no-dev --no-interaction --prefer-dist
 
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@v5
               if: hashFiles('package.json') != ''
               with:
                   node-version: ${{ inputs.node-version }}
@@ -99,7 +99,7 @@ jobs:
 
             - name: Upload zip artifact
               if: inputs.generate-zip
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v5
               with:
                   name: ${{ inputs.slug || github.event.repository.name }}
                   path: ${{ github.workspace }}/*.zip

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] - 2026-06-08
+
+### Changed
+
+- Bump GitHub Actions to their first Node 24 runtimes across all reusable
+  workflows: `actions/checkout` v4→v5, `actions/github-script` v7→v8,
+  `actions/setup-node` v4→v5, `actions/upload-artifact` v4→v5, and
+  `actions/cache` v4→v5. GitHub forces JavaScript actions off the
+  deprecated Node 20 runtime starting 2026-06-16.
+
 ## [0.9.0] - 2026-06-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -229,4 +229,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - WP integration workflow uses `wp-phpunit/wp-phpunit` Composer package instead of SVN checkout
 - Upgrade `actions/stale` from v9 to v10
 
+[0.10.0]: https://github.com/apermo/reusable-workflows/compare/v0.9.0...v0.10.0
+[0.9.0]: https://github.com/apermo/reusable-workflows/compare/v0.8.0...v0.9.0
+[0.8.0]: https://github.com/apermo/reusable-workflows/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/apermo/reusable-workflows/compare/v0.6.2...v0.7.0


### PR DESCRIPTION
## Background

GitHub forces JavaScript actions off the deprecated Node 20 runtime starting **2026-06-16**, with full removal on 2026-09-16.

## Changes

Bumps every action pinned to a Node 20 major to its first Node 24 major across all reusable workflows:

- `actions/checkout` v4 → v5
- `actions/github-script` v7 → v8
- `actions/setup-node` v4 → v5
- `actions/upload-artifact` v4 → v5
- `actions/cache` v4 → v5

Consumers reference these workflows via `@main`, so the fix propagates downstream on merge.

Closes #46