### PR TITLE
feat(commits)!: lower default subject max to 50

### DIFF
--- a/.github/workflows/reusable-conventional-commits.yml
+++ b/.github/workflows/reusable-conventional-commits.yml
@@ -7,7 +7,7 @@ on:
                 description: 'Maximum subject line length'
                 required: false
                 type: number
-                default: 72
+                default: 50
             allowed-types:
                 description: 'Pipe-separated list of allowed types'
                 required: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **BREAKING:** `reusable-conventional-commits.yml` — default `max-length` lowered from
+  `72` to `50` to match the org-wide commit-message standard (50-char subject, 72-char
+  body wrap). Caller repos that relied on the implicit 72 limit and have subjects longer
+  than 50 chars will start failing; pass `with: max-length: 72` to keep the previous
+  behavior. The `template-wordpress` `.husky/commit-msg` `MAX` should be lowered to 50 in
+  lock-step (tracked separately). (#38)
+
 ## [0.10.0] - 2026-06-08
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ Validates commit messages follow the Conventional Commits specification.
 | Input | Type | Default | Description |
 |-------|------|---------|-------------|
 | `max-length` | number | `50` | Max subject line length |
-| `allowed-types` | string | `feat\|fix\|docs\|style\|refactor\|test\|chore\|perf` | Allowed types |
+| `allowed-types` | string | `feat\|fix\|docs\|style\|refactor\|test\|chore\|perf\|ci\|build` | Allowed types |
 
 ```yaml
 jobs:

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ Validates commit messages follow the Conventional Commits specification.
 
 | Input | Type | Default | Description |
 |-------|------|---------|-------------|
-| `max-length` | number | `72` | Max subject line length |
+| `max-length` | number | `50` | Max subject line length |
 | `allowed-types` | string | `feat\|fix\|docs\|style\|refactor\|test\|chore\|perf` | Allowed types |
 
 ```yaml


### PR DESCRIPTION
Closes #38.

## Problem

`reusable-conventional-commits.yml` defaulted the subject `max-length` to **72**, conflicting with the org-wide commit standard (50-char subject, 72-char body wrap). Caller repos either accepted the loose CI default while running a stricter 50-char local hook (husky/commitlint) — a mismatch where local rejects what CI allows — or passed `with: max-length: 50` on every call site.

## Change

- Default `max-length` lowered `72` → `50` in `reusable-conventional-commits.yml`.
- README input table updated to reflect the new default.
- CHANGELOG entry under **`## [Unreleased]`** (no version bump) so this merges without triggering a release — the breaking default can ride in a deliberate future release once callers are checked.

## Breaking change

Caller repos that relied on the implicit 72 limit and have subjects longer than 50 chars will start failing. Opt back in with:

```yaml
with:
  max-length: 72
```

## Follow-up (separate repo, not in this PR)

`apermo/template-wordpress` `.husky/commit-msg` hardcodes `MAX=72` to mirror this workflow — lower it to 50 in lock-step.

## Notes

- This repo's own caller relies on the default, so its CI now enforces 50 — a built-in self-test (this PR's commit subject is 47 chars).
- A spot-check across `apermo/*` callers is recommended before the eventual release that ships this.