### PR TITLE
feat(actions): add extract-changelog-version composite action

### DIFF
--- a/.github/actions/extract-changelog-version/action.yml
+++ b/.github/actions/extract-changelog-version/action.yml
@@ -18,7 +18,7 @@ outputs:
         description: 'Full version string (e.g. 1.2.3 or 1.2.3-beta.1); empty unless ok/already_released'
         value: ${{ steps.extract.outputs.version }}
     base_version:
-        description: 'Version without prerelease/build suffix (e.g. 1.2.3)'
+        description: 'Version without prerelease/build suffix (e.g. 1.2.3); empty unless ok/already_released'
         value: ${{ steps.extract.outputs.base_version }}
     tag:
         description: 'Release tag (v + version); empty unless ok/already_released'

--- a/.github/actions/extract-changelog-version/action.yml
+++ b/.github/actions/extract-changelog-version/action.yml
@@ -1,0 +1,111 @@
+name: Extract CHANGELOG version
+description: >-
+    Selects and validates the release version from a Keep-a-Changelog file. Single source of truth
+    shared by reusable-pr-validation, reusable-release, and reusable-prerelease so their version
+    selection cannot diverge. Pure classifier — never fails the job; callers apply policy to result.
+
+inputs:
+    changelog-path:
+        description: 'Path to CHANGELOG.md'
+        required: false
+        default: 'CHANGELOG.md'
+
+outputs:
+    result:
+        description: 'no_version | malformed | already_released | ok'
+        value: ${{ steps.extract.outputs.result }}
+    version:
+        description: 'Full version string (e.g. 1.2.3 or 1.2.3-beta.1); empty unless ok/already_released'
+        value: ${{ steps.extract.outputs.version }}
+    base_version:
+        description: 'Version without prerelease/build suffix (e.g. 1.2.3)'
+        value: ${{ steps.extract.outputs.base_version }}
+    tag:
+        description: 'Release tag (v + version); empty unless ok/already_released'
+        value: ${{ steps.extract.outputs.tag }}
+    prerelease:
+        description: 'true when the version carries a prerelease suffix'
+        value: ${{ steps.extract.outputs.prerelease }}
+
+runs:
+    using: composite
+    steps:
+        - id: extract
+          shell: bash
+          env:
+              CHANGELOG_PATH: ${{ inputs.changelog-path }}
+          run: |
+              set -euo pipefail
+
+              result=no_version
+              version=
+              base_version=
+              tag=
+              prerelease=false
+
+              emit() {
+                  {
+                      echo "result=$result"
+                      echo "version=$version"
+                      echo "base_version=$base_version"
+                      echo "tag=$tag"
+                      echo "prerelease=$prerelease"
+                  } >> "$GITHUB_OUTPUT"
+              }
+
+              # Phase 1: first "## [ ... ]" heading whose label is not "Unreleased".
+              HEADING=$(grep -oP '^##\s+\[\K[^\]]+\](.*)$' "$CHANGELOG_PATH" \
+                  | grep -viP '^Unreleased\]' | head -n1 || true)
+
+              if [ -z "$HEADING" ]; then
+                  echo "No release version heading found — merge without release."
+                  emit
+                  exit 0
+              fi
+
+              LABEL="${HEADING%%]*}"
+              REST="${HEADING#*]}"
+
+              # A heading with no digit is prose (e.g. "[Yanked]"), not a botched release.
+              if ! printf '%s' "$LABEL" | grep -qP '[0-9]'; then
+                  echo "Top heading '[$LABEL]' is not a version — merge without release."
+                  emit
+                  exit 0
+              fi
+
+              # Strict SemVer 2.0.0 + Keep-a-Changelog date.
+              SEMVER='^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'
+              DATE_RE='^[[:space:]]*-[[:space:]]+[0-9]{4}-[0-9]{2}-[0-9]{2}'
+
+              if ! printf '%s' "$LABEL" | grep -qP "$SEMVER"; then
+                  result=malformed
+                  echo "::error::Malformed version heading '[$LABEL]' in $CHANGELOG_PATH — expected '## [X.Y.Z] - YYYY-MM-DD' (SemVer)."
+                  emit
+                  exit 0
+              fi
+
+              if ! printf '%s' "$REST" | grep -qP "$DATE_RE"; then
+                  result=malformed
+                  echo "::error::Version heading '[$LABEL]' in $CHANGELOG_PATH is missing a valid ' - YYYY-MM-DD' date."
+                  emit
+                  exit 0
+              fi
+
+              version="$LABEL"
+              base_version=$(printf '%s' "$version" | grep -oP '^[0-9]+\.[0-9]+\.[0-9]+')
+              tag="v$version"
+              if [[ "$version" == *"-"* ]]; then
+                  prerelease=true
+              fi
+
+              # Requires the caller checkout to have fetched tags (fetch-depth: 0 / fetch-tags).
+              if git tag -l "$tag" | grep -q .; then
+                  result=already_released
+                  echo "$tag already tagged — merge without release."
+                  emit
+                  exit 0
+              fi
+
+              result=ok
+              echo "Version: $version (new release)"
+              emit

--- a/.github/actions/extract-changelog-version/action.yml
+++ b/.github/actions/extract-changelog-version/action.yml
@@ -53,38 +53,50 @@ runs:
                   } >> "$GITHUB_OUTPUT"
               }
 
-              # Phase 1: first "## [ ... ]" heading whose label is not "Unreleased".
-              HEADING=$(grep -oP '^##\s+\[\K[^\]]+\](.*)$' "$CHANGELOG_PATH" \
-                  | grep -viP '^Unreleased\]' | head -n1 || true)
+              if [ ! -f "$CHANGELOG_PATH" ]; then
+                  echo "Changelog not found at '$CHANGELOG_PATH' — merge without release."
+                  emit
+                  exit 0
+              fi
 
-              if [ -z "$HEADING" ]; then
+              # Strict SemVer 2.0.0 + Keep-a-Changelog date (POSIX ERE — bash =~).
+              SEMVER='^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'
+              DATE_RE='^[[:space:]]*-[[:space:]]+[0-9]{4}-[0-9]{2}-[0-9]{2}'
+
+              # Phase 1: first "## [ ... ]" heading whose label is not "Unreleased".
+              LABEL=
+              REST=
+              while IFS= read -r line || [ -n "$line" ]; do
+                  if [[ "$line" =~ ^##[[:space:]]+\[([^]]+)\](.*)$ ]]; then
+                      candidate="${BASH_REMATCH[1]}"
+                      [ "${candidate,,}" = "unreleased" ] && continue
+                      LABEL="$candidate"
+                      REST="${BASH_REMATCH[2]}"
+                      break
+                  fi
+              done < "$CHANGELOG_PATH"
+
+              if [ -z "$LABEL" ]; then
                   echo "No release version heading found — merge without release."
                   emit
                   exit 0
               fi
 
-              LABEL="${HEADING%%]*}"
-              REST="${HEADING#*]}"
-
               # A heading with no digit is prose (e.g. "[Yanked]"), not a botched release.
-              if ! printf '%s' "$LABEL" | grep -qP '[0-9]'; then
+              if [[ ! "$LABEL" =~ [0-9] ]]; then
                   echo "Top heading '[$LABEL]' is not a version — merge without release."
                   emit
                   exit 0
               fi
 
-              # Strict SemVer 2.0.0 + Keep-a-Changelog date.
-              SEMVER='^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'
-              DATE_RE='^[[:space:]]*-[[:space:]]+[0-9]{4}-[0-9]{2}-[0-9]{2}'
-
-              if ! printf '%s' "$LABEL" | grep -qP "$SEMVER"; then
+              if [[ ! "$LABEL" =~ $SEMVER ]]; then
                   result=malformed
                   echo "::error::Malformed version heading '[$LABEL]' in $CHANGELOG_PATH — expected '## [X.Y.Z] - YYYY-MM-DD' (SemVer)."
                   emit
                   exit 0
               fi
 
-              if ! printf '%s' "$REST" | grep -qP "$DATE_RE"; then
+              if [[ ! "$REST" =~ $DATE_RE ]]; then
                   result=malformed
                   echo "::error::Version heading '[$LABEL]' in $CHANGELOG_PATH is missing a valid ' - YYYY-MM-DD' date."
                   emit
@@ -92,7 +104,9 @@ runs:
               fi
 
               version="$LABEL"
-              base_version=$(printf '%s' "$version" | grep -oP '^[0-9]+\.[0-9]+\.[0-9]+')
+              if [[ "$version" =~ ^([0-9]+\.[0-9]+\.[0-9]+) ]]; then
+                  base_version="${BASH_REMATCH[1]}"
+              fi
               tag="v$version"
               if [[ "$version" == *"-"* ]]; then
                   prerelease=true

--- a/.github/actions/extract-changelog-version/action.yml
+++ b/.github/actions/extract-changelog-version/action.yml
@@ -4,6 +4,17 @@ description: >-
     shared by reusable-pr-validation, reusable-release, and reusable-prerelease so their version
     selection cannot diverge. Pure classifier — never fails the job; callers apply policy to result.
 
+# Usage — reference by FULL path from a reusable workflow. A relative "./" path would
+# resolve against the *caller* repo's checkout, not this one, so it must be the owner/repo
+# form. The caller's checkout must fetch tags for the already_released result to work:
+#
+#     - uses: actions/checkout@v5
+#       with:
+#           fetch-depth: 0
+#     - id: version
+#       uses: apermo/reusable-workflows/.github/actions/extract-changelog-version@main
+#     # ... then branch on steps.version.outputs.result (ok | already_released | no_version | malformed)
+
 inputs:
     changelog-path:
         description: 'Path to CHANGELOG.md'
@@ -104,6 +115,7 @@ runs:
               fi
 
               version="$LABEL"
+              # Defensive: SEMVER already guarantees the X.Y.Z prefix, so this always matches.
               if [[ "$version" =~ ^([0-9]+\.[0-9]+\.[0-9]+) ]]; then
                   base_version="${BASH_REMATCH[1]}"
               fi
@@ -113,6 +125,8 @@ runs:
               fi
 
               # Requires the caller checkout to have fetched tags (fetch-depth: 0 / fetch-tags).
+              # grep -q . => "any output line means the tag exists"; the if consumes its exit,
+              # so the non-zero "no match" status does not trip set -o pipefail.
               if git tag -l "$tag" | grep -q .; then
                   result=already_released
                   echo "$tag already tagged — merge without release."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `extract-changelog-version` composite action — single source of truth for selecting and
+  validating the release version from `CHANGELOG.md` (first non-`Unreleased` heading, strict
+  SemVer 2.0.0 + ` - YYYY-MM-DD` date). Emits `result`/`version`/`base_version`/`tag`/`prerelease`.
+  Not yet wired into the reusable workflows — that follows in a second PR so the `@main` reference
+  resolves. Groundwork for unifying the three divergent extractors. (#43)
+
 ### Changed
 
 - **BREAKING:** `reusable-conventional-commits.yml` — default `max-length` lowered from


### PR DESCRIPTION
Refs #43. **PR 1 of 2.**

## Why

`reusable-pr-validation.yml`, `reusable-release.yml`, and `reusable-prerelease.yml` each re-implement "find the release version in CHANGELOG.md" with **two different selection rules**. They diverge when a standalone non-version, non-`Unreleased` heading sits above an untagged version (e.g. `## [Yanked]` over `## [0.8.0]`): pr-validation reports "no release" while release would fire one. This adds a single shared definition so the divergence becomes structurally impossible.

## This PR

Adds the composite action only — **nothing references it yet**, so it's inert and CI stays green. The rewire of the three workflows lands in PR 2 (a full-path `@main` reference can't resolve until the action exists on `main`).

`.github/actions/extract-changelog-version/action.yml`:
- Canonical logic = pr-validation's strict path: first non-`Unreleased` heading → SemVer 2.0.0 + ` - YYYY-MM-DD` date.
- Pure classifier — **never fails the job**; emits `result` (`no_version|malformed|already_released|ok`) plus `version`/`base_version`/`tag`/`prerelease`. Callers apply policy.

## Verification

Logic tested against fixtures on GNU grep (ubuntu container, stubbed git tags):

| Fixture | result | version | prerelease |
|---|---|---|---|
| `## [0.11.0] - 2026-06-08` | ok | 0.11.0 | false |
| `## [Unreleased]` over version | ok | 0.11.0 | false |
| `## [Yanked]` over version | **no_version** | — | — |
| `## [1.2] - …` | malformed | — | — |
| `## [1.2.3]` (no date) | malformed | — | — |
| already-tagged version | already_released | 0.10.0 | false |
| `## [0.11.0-beta.1] - …` | ok | 0.11.0-beta.1 | true |

`shellcheck` clean; `action.yml` valid YAML. CHANGELOG under `[Unreleased]` so this merges without triggering a release.