### PR TITLE
refactor: use shared changelog-version action

### DIFF
--- a/.github/actions/extract-changelog-version/action.yml
+++ b/.github/actions/extract-changelog-version/action.yml
@@ -4,15 +4,18 @@ description: >-
     shared by reusable-pr-validation, reusable-release, and reusable-prerelease so their version
     selection cannot diverge. Pure classifier — never fails the job; callers apply policy to result.
 
-# Usage — reference by FULL path from a reusable workflow. A relative "./" path would
-# resolve against the *caller* repo's checkout, not this one, so it must be the owner/repo
-# form. The caller's checkout must fetch tags for the already_released result to work:
+# Usage. The reusable-* workflows in THIS repo reference the action by relative path
+# (`uses: ./.github/actions/extract-changelog-version`) — GitHub resolves it against this
+# repo, and a same-repo `owner/repo/...@ref` reference is rejected from a reusable workflow.
+# An external repo using the action DIRECTLY (not via the reusable workflows) uses the full
+# path: `apermo/reusable-workflows/.github/actions/extract-changelog-version@<ref>`.
+# Either way the caller must checkout with fetch-depth: 0 so the already_released tag check works:
 #
 #     - uses: actions/checkout@v5
 #       with:
 #           fetch-depth: 0
 #     - id: version
-#       uses: apermo/reusable-workflows/.github/actions/extract-changelog-version@main
+#       uses: ./.github/actions/extract-changelog-version
 #     # ... then branch on steps.version.outputs.result (ok | already_released | no_version | malformed)
 
 inputs:

--- a/.github/workflows/reusable-pr-validation.yml
+++ b/.github/workflows/reusable-pr-validation.yml
@@ -23,7 +23,7 @@ jobs:
 
             - name: Extract version from CHANGELOG
               id: version
-              uses: apermo/reusable-workflows/.github/actions/extract-changelog-version@main
+              uses: ./.github/actions/extract-changelog-version
               with:
                   changelog-path: ${{ inputs.changelog-path }}
 

--- a/.github/workflows/reusable-pr-validation.yml
+++ b/.github/workflows/reusable-pr-validation.yml
@@ -43,6 +43,8 @@ jobs:
                       echo "::warning::CHANGELOG section for $VERSION appears empty"
                   fi
 
+            # Relies on the "Fail on malformed CHANGELOG" step above to trip failure() —
+            # the two are coupled, don't remove one without the other.
             - name: Comment on malformed CHANGELOG
               if: failure() && steps.version.outputs.result == 'malformed'
               uses: actions/github-script@v8

--- a/.github/workflows/reusable-pr-validation.yml
+++ b/.github/workflows/reusable-pr-validation.yml
@@ -13,7 +13,7 @@ jobs:
     validate:
         runs-on: ubuntu-latest
         outputs:
-            pr_version: ${{ steps.version.outputs.pr_version }}
+            pr_version: ${{ steps.version.outputs.version }}
             result: ${{ steps.version.outputs.result }}
             prerelease: ${{ steps.version.outputs.prerelease }}
         steps:
@@ -23,67 +23,19 @@ jobs:
 
             - name: Extract version from CHANGELOG
               id: version
-              run: |
-                  CHANGELOG="${{ inputs.changelog-path }}"
+              uses: apermo/reusable-workflows/.github/actions/extract-changelog-version@main
+              with:
+                  changelog-path: ${{ inputs.changelog-path }}
 
-                  # Phase 1: first "## [ ... ]" heading whose label is not "Unreleased".
-                  HEADING=$(grep -oP '^##\s+\[\K[^\]]+\](.*)$' "$CHANGELOG" \
-                      | grep -viP '^Unreleased\]' | head -n1 || true)
-
-                  if [ -z "$HEADING" ]; then
-                      echo "result=no_version" >> "$GITHUB_OUTPUT"
-                      echo "No release version heading found — merge without release."
-                      exit 0
-                  fi
-
-                  VERSION="${HEADING%%]*}"
-                  REST="${HEADING#*]}"
-
-                  # A heading with no digit is prose, not a botched release.
-                  if ! printf '%s' "$VERSION" | grep -qP '[0-9]'; then
-                      echo "result=no_version" >> "$GITHUB_OUTPUT"
-                      echo "Top heading '[$VERSION]' is not a version — merge without release."
-                      exit 0
-                  fi
-
-                  # Phase 2: strict SemVer 2.0.0 + Keep-a-Changelog date.
-                  SEMVER='^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$'
-                  DATE_RE='^[[:space:]]*-[[:space:]]+[0-9]{4}-[0-9]{2}-[0-9]{2}'
-
-                  if ! printf '%s' "$VERSION" | grep -qP "$SEMVER"; then
-                      echo "result=malformed" >> "$GITHUB_OUTPUT"
-                      echo "::error::Malformed version heading '[$VERSION]' in $CHANGELOG — expected '## [X.Y.Z] - YYYY-MM-DD' (SemVer)."
-                      exit 1
-                  fi
-
-                  if ! printf '%s' "$REST" | grep -qP "$DATE_RE"; then
-                      echo "result=malformed" >> "$GITHUB_OUTPUT"
-                      echo "::error::Version heading '[$VERSION]' in $CHANGELOG is missing a valid ' - YYYY-MM-DD' date."
-                      exit 1
-                  fi
-
-                  if git tag -l "v$VERSION" | grep -q .; then
-                      echo "pr_version=$VERSION" >> "$GITHUB_OUTPUT"
-                      echo "result=already_released" >> "$GITHUB_OUTPUT"
-                      echo "v$VERSION already tagged — merge without release."
-                      exit 0
-                  fi
-
-                  echo "pr_version=$VERSION" >> "$GITHUB_OUTPUT"
-
-                  if [[ "$VERSION" == *"-"* ]]; then
-                      echo "prerelease=true" >> "$GITHUB_OUTPUT"
-                  else
-                      echo "prerelease=false" >> "$GITHUB_OUTPUT"
-                  fi
-
-                  echo "result=ok" >> "$GITHUB_OUTPUT"
-                  echo "Version: $VERSION (new release)"
+            # The action is a pure classifier; pr-validation applies the fail policy.
+            - name: Fail on malformed CHANGELOG
+              if: steps.version.outputs.result == 'malformed'
+              run: exit 1
 
             - name: Check CHANGELOG entry
-              if: steps.version.outputs.prerelease == 'false'
+              if: steps.version.outputs.result == 'ok' && steps.version.outputs.prerelease == 'false'
               run: |
-                  VERSION="${{ steps.version.outputs.pr_version }}"
+                  VERSION="${{ steps.version.outputs.version }}"
                   SECTION=$(sed -n "/## \[$VERSION\]/,/## \[/p" ${{ inputs.changelog-path }} | head -n -1)
                   CONTENT=$(echo "$SECTION" | grep -v "^#" | grep -v "^$" | head -1)
 

--- a/.github/workflows/reusable-prerelease.yml
+++ b/.github/workflows/reusable-prerelease.yml
@@ -31,7 +31,7 @@ jobs:
 
             - name: Extract version from CHANGELOG
               id: version
-              uses: apermo/reusable-workflows/.github/actions/extract-changelog-version@main
+              uses: ./.github/actions/extract-changelog-version
               with:
                   changelog-path: ${{ inputs.changelog-path }}
 

--- a/.github/workflows/reusable-prerelease.yml
+++ b/.github/workflows/reusable-prerelease.yml
@@ -29,26 +29,28 @@ jobs:
                       exit 1
                   fi
 
-            - name: Extract version and create tag
+            - name: Extract version from CHANGELOG
               id: version
-              run: |
-                  VERSION=$(grep -m1 -oP '(?<=## \[)\d+\.\d+\.\d+[^]]*' ${{ inputs.changelog-path }} || echo "")
+              uses: apermo/reusable-workflows/.github/actions/extract-changelog-version@main
+              with:
+                  changelog-path: ${{ inputs.changelog-path }}
 
-                  if [ -z "$VERSION" ]; then
-                      echo "::error::No version found in ${{ inputs.changelog-path }}"
+            - name: Build prerelease tag
+              id: tag
+              run: |
+                  RESULT="${{ steps.version.outputs.result }}"
+                  if [ "$RESULT" != "ok" ] && [ "$RESULT" != "already_released" ]; then
+                      echo "::error::No valid version heading in ${{ inputs.changelog-path }} (result: $RESULT)."
                       exit 1
                   fi
-
-                  BASE_VERSION=$(echo "$VERSION" | grep -oP '^\d+\.\d+\.\d+')
-                  TAG="v${BASE_VERSION}-${{ github.event.inputs.label }}"
-
+                  TAG="v${{ steps.version.outputs.base_version }}-${{ github.event.inputs.label }}"
                   echo "tag=$TAG" >> "$GITHUB_OUTPUT"
                   echo "Tag: $TAG"
 
             - name: Create prerelease
               run: |
-                  gh release create "${{ steps.version.outputs.tag }}" \
-                      --title "${{ steps.version.outputs.tag }}" \
+                  gh release create "${{ steps.tag.outputs.tag }}" \
+                      --title "${{ steps.tag.outputs.tag }}" \
                       --target "${{ github.ref_name }}" \
                       --generate-notes \
                       --prerelease
@@ -72,6 +74,6 @@ jobs:
                               issue_number: pr.number,
                               owner: context.repo.owner,
                               repo: context.repo.repo,
-                              body: `Prerelease [${{ steps.version.outputs.tag }}](https://github.com/${context.repo.owner}/${context.repo.repo}/releases/tag/${{ steps.version.outputs.tag }}) created.`
+                              body: `Prerelease [${{ steps.tag.outputs.tag }}](https://github.com/${context.repo.owner}/${context.repo.repo}/releases/tag/${{ steps.tag.outputs.tag }}) created.`
                           });
                       }

--- a/.github/workflows/reusable-prerelease.yml
+++ b/.github/workflows/reusable-prerelease.yml
@@ -37,13 +37,15 @@ jobs:
 
             - name: Build prerelease tag
               id: tag
+              env:
+                  LABEL: ${{ github.event.inputs.label }}
               run: |
                   RESULT="${{ steps.version.outputs.result }}"
                   if [ "$RESULT" != "ok" ] && [ "$RESULT" != "already_released" ]; then
                       echo "::error::No valid version heading in ${{ inputs.changelog-path }} (result: $RESULT)."
                       exit 1
                   fi
-                  TAG="v${{ steps.version.outputs.base_version }}-${{ github.event.inputs.label }}"
+                  TAG="v${{ steps.version.outputs.base_version }}-$LABEL"
                   echo "tag=$TAG" >> "$GITHUB_OUTPUT"
                   echo "Tag: $TAG"
 

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -33,7 +33,7 @@ jobs:
 
             - name: Extract version from CHANGELOG
               id: version
-              uses: apermo/reusable-workflows/.github/actions/extract-changelog-version@main
+              uses: ./.github/actions/extract-changelog-version
               with:
                   changelog-path: ${{ inputs.changelog-path }}
 

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -33,38 +33,20 @@ jobs:
 
             - name: Extract version from CHANGELOG
               id: version
-              run: |
-                  VERSION=$(grep -m1 -oP '(?<=## \[)\d+\.\d+\.\d+[^]]*' ${{ inputs.changelog-path }} || echo "")
+              uses: apermo/reusable-workflows/.github/actions/extract-changelog-version@main
+              with:
+                  changelog-path: ${{ inputs.changelog-path }}
 
-                  if [ -z "$VERSION" ]; then
-                      echo "skip=true" >> "$GITHUB_OUTPUT"
-                      echo "No version found, skipping release."
-                      exit 0
-                  fi
-
-                  TAG="v$VERSION"
-
-                  if git tag -l "$TAG" | grep -q "$TAG"; then
-                      echo "skip=true" >> "$GITHUB_OUTPUT"
-                      echo "Tag $TAG already exists, skipping."
-                      exit 0
-                  fi
-
-                  echo "version=$VERSION" >> "$GITHUB_OUTPUT"
-                  echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-                  echo "skip=false" >> "$GITHUB_OUTPUT"
-
-                  if [[ "$VERSION" == *"-"* ]]; then
-                      echo "prerelease=true" >> "$GITHUB_OUTPUT"
-                  else
-                      echo "prerelease=false" >> "$GITHUB_OUTPUT"
-                  fi
+            # ok => release; no_version/already_released => skip; malformed => fail loudly
+            # (pr-validation should have caught it pre-merge).
+            - name: Fail on malformed CHANGELOG
+              if: steps.version.outputs.result == 'malformed'
+              run: exit 1
 
             - name: Delete old prerelease artifacts on final release
-              if: steps.version.outputs.skip == 'false' && steps.version.outputs.prerelease == 'false'
+              if: steps.version.outputs.result == 'ok' && steps.version.outputs.prerelease == 'false'
               run: |
-                  BASE_VERSION=$(echo "${{ steps.version.outputs.version }}" | grep -oP '^\d+\.\d+\.\d+')
-                  for tag in $(git tag -l "v${BASE_VERSION}-*"); do
+                  for tag in $(git tag -l "v${{ steps.version.outputs.base_version }}-*"); do
                       echo "Deleting prerelease tag: $tag"
                       gh release delete "$tag" --yes --cleanup-tag || true
                   done
@@ -72,7 +54,7 @@ jobs:
                   GH_TOKEN: ${{ secrets.release-token || secrets.GITHUB_TOKEN }}
 
             - name: Create release
-              if: steps.version.outputs.skip == 'false'
+              if: steps.version.outputs.result == 'ok'
               run: |
                   PRERELEASE_FLAG=""
                   if [ "${{ steps.version.outputs.prerelease }}" = "true" ]; then
@@ -87,7 +69,7 @@ jobs:
                   GH_TOKEN: ${{ secrets.release-token || secrets.GITHUB_TOKEN }}
 
             - name: Comment on merged PR
-              if: steps.version.outputs.skip == 'false'
+              if: steps.version.outputs.result == 'ok'
               uses: actions/github-script@v8
               with:
                   github-token: ${{ secrets.release-token || secrets.GITHUB_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,10 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `reusable-pr-validation.yml`, `reusable-release.yml`, and `reusable-prerelease.yml` now extract
   the CHANGELOG version via the shared `extract-changelog-version` action instead of three
   divergent inline implementations, so their version selection can no longer diverge (the
-  `## [Yanked]`-over-an-untagged-version case now resolves consistently to "no release"). **Behavior
-  change:** `reusable-prerelease.yml` now requires a strict `## [X.Y.Z] - YYYY-MM-DD` heading
-  (it previously accepted an undated `## [X.Y.Z]`); `reusable-release.yml` now fails loudly on a
-  malformed top heading instead of silently skipping. (#43)
+  `## [Yanked]`-over-an-untagged-version case now resolves consistently to "no release"). (#43)
+- **BREAKING:** `reusable-prerelease.yml` now requires a strict `## [X.Y.Z] - YYYY-MM-DD` heading;
+  it previously accepted an undated `## [X.Y.Z]`. A prerelease cut from a release branch whose top
+  entry is undated will now fail — add the date, or open an issue to relax the prerelease path.
+  Relatedly, `reusable-release.yml` now fails loudly on a malformed top heading instead of silently
+  skipping (pr-validation should catch it pre-merge). (#43)
 - **BREAKING:** `reusable-conventional-commits.yml` — default `max-length` lowered from
   `72` to `50` to match the org-wide commit-message standard (50-char subject, 72-char
   body wrap). Caller repos that relied on the implicit 72 limit and have subjects longer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `extract-changelog-version` composite action — single source of truth for selecting and
   validating the release version from `CHANGELOG.md` (first non-`Unreleased` heading, strict
   SemVer 2.0.0 + ` - YYYY-MM-DD` date). Emits `result`/`version`/`base_version`/`tag`/`prerelease`.
-  Not yet wired into the reusable workflows — that follows in a second PR so the `@main` reference
-  resolves. Groundwork for unifying the three divergent extractors. (#43)
+  (#43)
 
 ### Changed
 
+- `reusable-pr-validation.yml`, `reusable-release.yml`, and `reusable-prerelease.yml` now extract
+  the CHANGELOG version via the shared `extract-changelog-version` action instead of three
+  divergent inline implementations, so their version selection can no longer diverge (the
+  `## [Yanked]`-over-an-untagged-version case now resolves consistently to "no release"). **Behavior
+  change:** `reusable-prerelease.yml` now requires a strict `## [X.Y.Z] - YYYY-MM-DD` heading
+  (it previously accepted an undated `## [X.Y.Z]`); `reusable-release.yml` now fails loudly on a
+  malformed top heading instead of silently skipping. (#43)
 - **BREAKING:** `reusable-conventional-commits.yml` — default `max-length` lowered from
   `72` to `50` to match the org-wide commit-message standard (50-char subject, 72-char
   body wrap). Caller repos that relied on the implicit 72 limit and have subjects longer

--- a/README.md
+++ b/README.md
@@ -365,9 +365,11 @@ never fails the job; callers apply their own policy to the `result` output.
 | `tag` | Release tag (`v` + version); empty unless `ok`/`already_released` |
 | `prerelease` | `true` when the version carries a prerelease suffix |
 
-Reference it by **full path** (a relative `./` path would resolve against the caller repo's
-checkout, not this one), and check out with `fetch-depth: 0` so the `already_released` tag check
-works:
+The reusable workflows in this repo reference it by relative path
+(`./.github/actions/extract-changelog-version`), since GitHub resolves that against this repo and
+rejects a same-repo `owner/repo/...@ref` reference from a reusable workflow. An external repo using
+the action **directly** references the full path with a ref, as below. Either way, check out with
+`fetch-depth: 0` so the `already_released` tag check works:
 
 ```yaml
 steps:

--- a/README.md
+++ b/README.md
@@ -343,6 +343,42 @@ jobs:
     uses: apermo/reusable-workflows/.github/workflows/reusable-stale.yml@main
 ```
 
+## Composite actions
+
+### `extract-changelog-version`
+
+Selects and validates the release version from a Keep-a-Changelog `CHANGELOG.md` (first
+non-`Unreleased` `## [...]` heading, strict SemVer 2.0.0 + ` - YYYY-MM-DD` date). It is the single
+source of truth used by `reusable-pr-validation.yml`, `reusable-release.yml`, and
+`reusable-prerelease.yml` so their version selection cannot diverge. It is a pure classifier — it
+never fails the job; callers apply their own policy to the `result` output.
+
+| Input | Type | Default | Description |
+|-------|------|---------|-------------|
+| `changelog-path` | string | `"CHANGELOG.md"` | Path to the CHANGELOG file |
+
+| Output | Description |
+|--------|-------------|
+| `result` | `no_version` \| `malformed` \| `already_released` \| `ok` |
+| `version` | Full version (e.g. `1.2.3` or `1.2.3-beta.1`); empty unless `ok`/`already_released` |
+| `base_version` | Version without prerelease/build suffix (e.g. `1.2.3`); empty unless `ok`/`already_released` |
+| `tag` | Release tag (`v` + version); empty unless `ok`/`already_released` |
+| `prerelease` | `true` when the version carries a prerelease suffix |
+
+Reference it by **full path** (a relative `./` path would resolve against the caller repo's
+checkout, not this one), and check out with `fetch-depth: 0` so the `already_released` tag check
+works:
+
+```yaml
+steps:
+  - uses: actions/checkout@v5
+    with:
+      fetch-depth: 0
+  - id: version
+    uses: apermo/reusable-workflows/.github/actions/extract-changelog-version@main
+  # branch on steps.version.outputs.result
+```
+
 ## License
 
 MIT — see [LICENSE](LICENSE) for details.


### PR DESCRIPTION
Closes #43. **PR 2 of 2** (follows #50, which added the action).

## What

Wires the three workflows that extract the release version from CHANGELOG.md to the shared `extract-changelog-version` composite action (added in #50, now on `main`), replacing three divergent inline implementations:

| Workflow | Was | Now |
|----------|-----|-----|
| `reusable-pr-validation.yml` | inline strict state machine | calls action; `malformed` → fail (+ existing PR comment); job outputs map from action |
| `reusable-release.yml` | loose `grep -m1 -oP` + `skip` flag | calls action; `ok` → release, `no_version`/`already_released` → skip, `malformed` → fail |
| `reusable-prerelease.yml` | loose `grep -m1 -oP` | calls action; builds `v<base_version>-<label>` on `ok`/`already_released`, fails otherwise |

The workflows reference the action by **relative path** (`./.github/actions/extract-changelog-version`). GitHub rejects a same-repo `owner/repo/...@ref` reference from a reusable workflow (`Can't find action.yml` even though it's on `main`) and resolves `./` against this repo; external repos using the action *directly* still use the full `@ref` path. All three callers checkout with `fetch-depth: 0`, so the `already_released` tag check works.

## Why

`reusable-release`/`reusable-prerelease` used a loose digit-leading `grep` while `pr-validation` used a strict state machine. They diverged on e.g. `## [Yanked]` over an untagged version (validation said "no release", release would fire one). Now all three share one definition — divergence is structurally impossible.

## ⚠️ Behavior changes (also in CHANGELOG)

- **prerelease** now requires a strict `## [X.Y.Z] - YYYY-MM-DD` heading; it previously accepted an **undated** `## [X.Y.Z]`. If your prerelease flow cuts from a release branch whose top entry is undated, it will now fail — say so and I'll relax the prerelease path.
- **release** now **fails loudly** on a malformed top heading instead of silently skipping (pr-validation should catch it pre-merge anyway).

## Docs
- README gains a "Composite actions" section (inputs/outputs + usage + `fetch-depth: 0` note).
- CHANGELOG entry under `[Unreleased]` (no version heading → merges without triggering a release).

## Verification
- Self-CI is green: this repo's `pr-validation` → `reusable-pr-validation` → the action runs live (CHANGELOG top is `[Unreleased]` → `result=no_version` → passes, merge-without-release). This also confirmed the relative-path resolution (an earlier full-path `@main` attempt failed with `Can't find action.yml`).