### PR TITLE
chore: release 0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.11.0] - 2026-06-13
 
 ### Added
 
@@ -256,6 +256,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - WP integration workflow uses `wp-phpunit/wp-phpunit` Composer package instead of SVN checkout
 - Upgrade `actions/stale` from v9 to v10
 
+[0.11.0]: https://github.com/apermo/reusable-workflows/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/apermo/reusable-workflows/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/apermo/reusable-workflows/compare/v0.8.0...v0.9.0
 [0.8.0]: https://github.com/apermo/reusable-workflows/compare/v0.7.0...v0.8.0


### PR DESCRIPTION
Promotes `[Unreleased]` to `## [0.11.0] - 2026-06-13` to cut the release. Merging triggers `reusable-release.yml` (tag `v0.11.0` + GitHub release).

### Ships
- **#43** — unified CHANGELOG version extraction across pr-validation/release/prerelease via the shared composite action.
- **BREAKING (#43)** — `reusable-prerelease.yml` now requires a strict `## [X.Y.Z] - YYYY-MM-DD` heading; `reusable-release.yml` fails loudly on a malformed top heading.
- **BREAKING (#38)** — `reusable-conventional-commits.yml` default `max-length` 72→50. Caller repos with >50-char subjects that didn't pin `max-length: 72` will start failing. (Rollout gate #49 — caller spot-check + template-wordpress husky — intentionally shipped ahead per maintainer decision.)