### PR TITLE
fix: resolve composite action via checkout

### DIFF
--- a/.github/actions/extract-changelog-version/action.yml
+++ b/.github/actions/extract-changelog-version/action.yml
@@ -4,18 +4,22 @@ description: >-
     shared by reusable-pr-validation, reusable-release, and reusable-prerelease so their version
     selection cannot diverge. Pure classifier — never fails the job; callers apply policy to result.
 
-# Usage. The reusable-* workflows in THIS repo reference the action by relative path
-# (`uses: ./.github/actions/extract-changelog-version`) — GitHub resolves it against this
-# repo, and a same-repo `owner/repo/...@ref` reference is rejected from a reusable workflow.
-# An external repo using the action DIRECTLY (not via the reusable workflows) uses the full
-# path: `apermo/reusable-workflows/.github/actions/extract-changelog-version@<ref>`.
-# Either way the caller must checkout with fetch-depth: 0 so the already_released tag check works:
+# Usage. The action lives in the same repo as the reusable workflows that use it, so they
+# check this repo out into a subdir and reference it locally. A bare relative "./" resolves
+# against the CONSUMER's checkout (which has no .github/actions/), and a same-repo
+# "owner/repo/...@ref" ref fails to resolve from a reusable workflow — the checkout side-steps
+# both. The caller must checkout with fetch-depth: 0 so the already_released tag check works:
 #
 #     - uses: actions/checkout@v5
 #       with:
 #           fetch-depth: 0
+#     - uses: actions/checkout@v5
+#       with:
+#           repository: apermo/reusable-workflows
+#           ref: main
+#           path: .rw-actions
 #     - id: version
-#       uses: ./.github/actions/extract-changelog-version
+#       uses: ./.rw-actions/.github/actions/extract-changelog-version
 #     # ... then branch on steps.version.outputs.result (ok | already_released | no_version | malformed)
 
 inputs:

--- a/.github/workflows/reusable-pr-validation.yml
+++ b/.github/workflows/reusable-pr-validation.yml
@@ -21,9 +21,19 @@ jobs:
               with:
                   fetch-depth: 0
 
+            # extract-changelog-version lives in this repo; check it out so a consumer
+            # repo (whose checkout above does not contain it) can resolve it. A relative
+            # ./ ref alone resolves against the consumer's workspace and fails.
+            - name: Check out reusable-workflows actions
+              uses: actions/checkout@v5
+              with:
+                  repository: apermo/reusable-workflows
+                  ref: main
+                  path: .rw-actions
+
             - name: Extract version from CHANGELOG
               id: version
-              uses: ./.github/actions/extract-changelog-version
+              uses: ./.rw-actions/.github/actions/extract-changelog-version
               with:
                   changelog-path: ${{ inputs.changelog-path }}
 

--- a/.github/workflows/reusable-prerelease.yml
+++ b/.github/workflows/reusable-prerelease.yml
@@ -29,9 +29,19 @@ jobs:
                       exit 1
                   fi
 
+            # extract-changelog-version lives in this repo; check it out so a consumer
+            # repo (whose checkout above does not contain it) can resolve it. A relative
+            # ./ ref alone resolves against the consumer's workspace and fails.
+            - name: Check out reusable-workflows actions
+              uses: actions/checkout@v5
+              with:
+                  repository: apermo/reusable-workflows
+                  ref: main
+                  path: .rw-actions
+
             - name: Extract version from CHANGELOG
               id: version
-              uses: ./.github/actions/extract-changelog-version
+              uses: ./.rw-actions/.github/actions/extract-changelog-version
               with:
                   changelog-path: ${{ inputs.changelog-path }}
 

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -31,9 +31,19 @@ jobs:
               with:
                   fetch-depth: 0
 
+            # extract-changelog-version lives in this repo; check it out so a consumer
+            # repo (whose checkout above does not contain it) can resolve it. A relative
+            # ./ ref alone resolves against the consumer's workspace and fails.
+            - name: Check out reusable-workflows actions
+              uses: actions/checkout@v5
+              with:
+                  repository: apermo/reusable-workflows
+                  ref: main
+                  path: .rw-actions
+
             - name: Extract version from CHANGELOG
               id: version
-              uses: ./.github/actions/extract-changelog-version
+              uses: ./.rw-actions/.github/actions/extract-changelog-version
               with:
                   changelog-path: ${{ inputs.changelog-path }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- `reusable-pr-validation.yml`, `reusable-release.yml`, and `reusable-prerelease.yml` now check
+  `apermo/reusable-workflows` out into a subdir and reference the `extract-changelog-version` action
+  locally from there, instead of a bare `./` path. The relative path resolved against the
+  *consumer's* checkout (which has no `.github/actions/`), so every external caller failed with
+  "Can't find action.yml"; a same-repo `owner/repo/...@ref` ref doesn't resolve from a reusable
+  workflow either. Regression from 0.11.0. (#43)
+
 ## [0.11.0] - 2026-06-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -365,10 +365,10 @@ never fails the job; callers apply their own policy to the `result` output.
 | `tag` | Release tag (`v` + version); empty unless `ok`/`already_released` |
 | `prerelease` | `true` when the version carries a prerelease suffix |
 
-The reusable workflows in this repo reference it by relative path
-(`./.github/actions/extract-changelog-version`), since GitHub resolves that against this repo and
-rejects a same-repo `owner/repo/...@ref` reference from a reusable workflow. An external repo using
-the action **directly** references the full path with a ref, as below. Either way, check out with
+Because the action lives in the same repo as the reusable workflows that consume it, those
+workflows check this repo out into a subdir and reference it locally — a bare relative
+`./.github/actions/...` resolves against the *caller's* checkout (which has no `.github/actions/`),
+and a same-repo `owner/repo/...@ref` ref fails to resolve from a reusable workflow. Check out with
 `fetch-depth: 0` so the `already_released` tag check works:
 
 ```yaml
@@ -376,8 +376,13 @@ steps:
   - uses: actions/checkout@v5
     with:
       fetch-depth: 0
+  - uses: actions/checkout@v5
+    with:
+      repository: apermo/reusable-workflows
+      ref: main
+      path: .rw-actions
   - id: version
-    uses: apermo/reusable-workflows/.github/actions/extract-changelog-version@main
+    uses: ./.rw-actions/.github/actions/extract-changelog-version
   # branch on steps.version.outputs.result
 ```
 


### PR DESCRIPTION
## Problem

`reusable-pr-validation.yml`, `reusable-release.yml`, and `reusable-prerelease.yml` referenced the same-repo `extract-changelog-version` composite action by a bare relative path (`./.github/actions/...`). A relative action path resolves against the **caller's** checkout (`GITHUB_WORKSPACE`) — a consumer repo's workspace, which has no `.github/actions/`:

    Can't find 'action.yml' ... under '.../<consumer>/.github/actions/extract-changelog-version'.

Regression from 0.11.0 (`baadc0c`). It passed this repo's own CI only because the self-test caller *is* this repo.

## Why not just the full `owner/repo@ref` path?

That fixes external consumers but **breaks this repo's own self-test**: a same-repo `apermo/reusable-workflows/...@ref` action ref does not resolve from a reusable workflow (confirmed — GitHub downloads the repo at the right SHA but reports `Can't find action.yml`). No single simple ref works for both.

## Fix

Each workflow checks `apermo/reusable-workflows` out into a subdir (`.rw-actions`) and references the action locally from there (`uses: ./.rw-actions/.github/actions/extract-changelog-version`). The action's `run:` still executes against `GITHUB_WORKSPACE` (the caller's checkout), so it reads the caller's CHANGELOG/tags. Works for **both** external consumers and this repo's self-test. Action/README usage notes + CHANGELOG updated.

## Verify
- This PR's `pr-validation` self-test.
- After merge to `main`, re-run `pr-validation / validate` on apermo/template-wordpress#48 → expect green.

Refs #43.