### PR TITLE
fix: pin action checkout to workflow sha

### DIFF
--- a/.github/actions/extract-changelog-version/action.yml
+++ b/.github/actions/extract-changelog-version/action.yml
@@ -16,11 +16,15 @@ description: >-
 #     - uses: actions/checkout@v5
 #       with:
 #           repository: apermo/reusable-workflows
-#           ref: main
+#           ref: ${{ github.job_workflow_sha }}   # matches the workflow version the consumer pinned
 #           path: .rw-actions
+#           persist-credentials: false
 #     - id: version
 #       uses: ./.rw-actions/.github/actions/extract-changelog-version
 #     # ... then branch on steps.version.outputs.result (ok | already_released | no_version | malformed)
+#
+# Note: the checkout leaves a .rw-actions/ dir in the caller's workspace — exclude it from any
+# in-job `git add`/archive/packaging steps.
 
 inputs:
     changelog-path:

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -18,3 +18,6 @@ jobs:
         steps:
             - uses: actions/checkout@v5
             - uses: reviewdog/action-actionlint@v1
+              with:
+                  # actionlint 1.7.x doesn't know the (valid) github.job_workflow_sha context.
+                  actionlint_flags: -ignore 'property "job_workflow_sha" is not defined'

--- a/.github/workflows/reusable-pr-validation.yml
+++ b/.github/workflows/reusable-pr-validation.yml
@@ -28,8 +28,12 @@ jobs:
               uses: actions/checkout@v5
               with:
                   repository: apermo/reusable-workflows
-                  ref: main
+                  # Pin to THIS reusable workflow's own commit so the action matches the
+                  # workflow version the consumer pinned (and so a PR's self-test exercises
+                  # the PR's action, not main's).
+                  ref: ${{ github.job_workflow_sha }}
                   path: .rw-actions
+                  persist-credentials: false
 
             - name: Extract version from CHANGELOG
               id: version

--- a/.github/workflows/reusable-prerelease.yml
+++ b/.github/workflows/reusable-prerelease.yml
@@ -36,8 +36,12 @@ jobs:
               uses: actions/checkout@v5
               with:
                   repository: apermo/reusable-workflows
-                  ref: main
+                  # Pin to THIS reusable workflow's own commit so the action matches the
+                  # workflow version the consumer pinned (and so a PR's self-test exercises
+                  # the PR's action, not main's).
+                  ref: ${{ github.job_workflow_sha }}
                   path: .rw-actions
+                  persist-credentials: false
 
             - name: Extract version from CHANGELOG
               id: version

--- a/.github/workflows/reusable-release.yml
+++ b/.github/workflows/reusable-release.yml
@@ -38,8 +38,12 @@ jobs:
               uses: actions/checkout@v5
               with:
                   repository: apermo/reusable-workflows
-                  ref: main
+                  # Pin to THIS reusable workflow's own commit so the action matches the
+                  # workflow version the consumer pinned (and so a PR's self-test exercises
+                  # the PR's action, not main's).
+                  ref: ${{ github.job_workflow_sha }}
                   path: .rw-actions
+                  persist-credentials: false
 
             - name: Extract version from CHANGELOG
               id: version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   "Can't find action.yml"; a same-repo `owner/repo/...@ref` ref doesn't resolve from a reusable
   workflow either. Regression from 0.11.0. (#43)
 
+### Changed
+
+- The action checkout in `reusable-pr-validation.yml`, `reusable-release.yml`, and
+  `reusable-prerelease.yml` is pinned to `${{ github.job_workflow_sha }}` (the reusable workflow's
+  own commit) instead of `main`, so consumers that pin the workflow to a version get the matching
+  action, and a PR's self-test exercises the PR's action rather than `main`'s. The checkout also
+  sets `persist-credentials: false`. (#43)
+
 ## [0.11.0] - 2026-06-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -379,12 +379,16 @@ steps:
   - uses: actions/checkout@v5
     with:
       repository: apermo/reusable-workflows
-      ref: main
+      ref: ${{ github.job_workflow_sha }}   # matches the pinned workflow version
       path: .rw-actions
+      persist-credentials: false
   - id: version
     uses: ./.rw-actions/.github/actions/extract-changelog-version
   # branch on steps.version.outputs.result
 ```
+
+The checkout leaves a `.rw-actions/` directory in the caller's workspace; exclude it from any
+in-job `git add`/archive/packaging steps in the same job.
 
 ## License
 


### PR DESCRIPTION
Follow-up to #53 (post-merge review). Pins the `extract-changelog-version` action checkout in the three reusable workflows to `${{ github.job_workflow_sha }}` (the reusable workflow's own commit) instead of `main`.

## Why
With `ref: main`, a consumer pinning the workflow to a version tag got **workflow@vX + action@main** (incomplete pin), and this repo's own pr-validation self-test always exercised `main`'s action — not a PR branch's — which is the exact blind spot that let the original `./` regression through. `job_workflow_sha` resolves the action at the same commit as the workflow, fixing both.

## Also
- `persist-credentials: false` on the action checkout (token was landing in `.rw-actions/.git/config`).
- Documented the `.rw-actions` workspace artifact in the action comment + README.
- `Lint workflows`: added a targeted `-ignore` for actionlint 1.7.x not knowing the (valid) `github.job_workflow_sha` context.

## Verify
- This PR's `pr-validation` self-test confirms `job_workflow_sha` resolves at runtime (checkout fetches the action at that SHA).
- `Lint workflows` stays green with the ignore.

Refs #43.