### PR TITLE
chore: release 0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.11.1] - 2026-06-13
 
 ### Fixed
 
@@ -275,6 +275,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - WP integration workflow uses `wp-phpunit/wp-phpunit` Composer package instead of SVN checkout
 - Upgrade `actions/stale` from v9 to v10
 
+[0.11.1]: https://github.com/apermo/reusable-workflows/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/apermo/reusable-workflows/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/apermo/reusable-workflows/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/apermo/reusable-workflows/compare/v0.8.0...v0.9.0


### PR DESCRIPTION
Promotes `[Unreleased]` to `## [0.11.1] - 2026-06-13`. Merging triggers `reusable-release.yml` (tag `v0.11.1` + GitHub release).

Patch release — fixes the 0.11.0 regression where the reusable workflows couldn't resolve the `extract-changelog-version` action on consumer repos:
- **Fixed:** workflows now check the action out of `apermo/reusable-workflows` into a subdir and reference it locally (bare `./` resolved against the consumer's checkout). (#43)
- **Changed:** action checkout pinned to `${{ github.job_workflow_sha }}` (matches the consumer's workflow pin + restores self-test coverage); `persist-credentials: false`. (#43)

This is also the first release cut through the fixed release workflow.