### PR TITLE
fix(plugin-check): move wp-env out of scanned tree

### DIFF
--- a/.github/workflows/reusable-plugin-check.yml
+++ b/.github/workflows/reusable-plugin-check.yml
@@ -69,17 +69,18 @@ jobs:
         steps:
             - uses: actions/checkout@v5
 
-            # plugin-check-action provisions its own wp-env (plugin-check plugin,
-            # port mapping, plugin slug) only when no .wp-env.json is present. A repo
-            # one (required by reusable-wp-e2e.yml) makes the action skip its setup and
-            # then die on "Environment not initialized". Move it aside for the run.
+            # plugin-check-action provisions its own wp-env only when no
+            # .wp-env.json is present; a committed one (needed by reusable-wp-e2e.yml)
+            # makes the action skip setup and die on "Environment not initialized".
+            # Stash it in $RUNNER_TEMP for the run — renaming it to an in-tree dotfile
+            # instead trips plugin-check's "hidden files are not permitted" error.
             - name: Hide repo wp-env config
               id: hide-wp-env
               run: |
                   moved=
                   for f in .wp-env.json .wp-env.override.json; do
                       if [ -f "$f" ]; then
-                          mv "$f" "$f.plugin-check-bak"
+                          mv "$f" "$RUNNER_TEMP/$f.plugin-check-bak"
                           moved="$moved $f"
                       fi
                   done
@@ -107,7 +108,7 @@ jobs:
               if: always() && steps.hide-wp-env.outputs.moved == 'true'
               run: |
                   for f in .wp-env.json .wp-env.override.json; do
-                      if [ -f "$f.plugin-check-bak" ]; then
-                          mv "$f.plugin-check-bak" "$f"
+                      if [ -f "$RUNNER_TEMP/$f.plugin-check-bak" ]; then
+                          mv "$RUNNER_TEMP/$f.plugin-check-bak" "$f"
                       fi
                   done

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.11.2] - 2026-06-21
 
 ### Fixed
 
@@ -286,6 +286,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - WP integration workflow uses `wp-phpunit/wp-phpunit` Composer package instead of SVN checkout
 - Upgrade `actions/stale` from v9 to v10
 
+[0.11.2]: https://github.com/apermo/reusable-workflows/compare/v0.11.1...v0.11.2
 [0.11.1]: https://github.com/apermo/reusable-workflows/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/apermo/reusable-workflows/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/apermo/reusable-workflows/compare/v0.9.0...v0.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- `reusable-plugin-check.yml` now stashes a repo's `.wp-env.json` /
+  `.wp-env.override.json` in `$RUNNER_TEMP` while plugin-check runs, instead of
+  renaming it to an in-tree `.plugin-check-bak` dotfile. The dotfile sat in the
+  scanned plugin directory, so plugin-check failed with "Hidden files are not
+  permitted" for every repo that commits a wp-env config. Regression from the
+  wp-env hide step added in 0.11.0.
+
 ## [0.11.1] - 2026-06-13
 
 ### Fixed


### PR DESCRIPTION
## Problem

`reusable-plugin-check.yml` hides a repo's committed `.wp-env.json` before running plugin-check (so `wordpress/plugin-check-action` provisions its own wp-env instead of dying on "Environment not initialized"). It did so by renaming the file in place:

```
mv .wp-env.json .wp-env.json.plugin-check-bak
```

That backup is a **dotfile in the scanned plugin directory**, so plugin-check flags it:

```
FILE: .wp-env.json.plugin-check-bak
ERROR  hidden_files  Hidden files are not permitted.
```

The check then fails for **every** consumer repo that commits a wp-env config. This is currently red on `apermo/apermo-notify` (PR #22 and `main`).

## Fix

Stash the file in `$RUNNER_TEMP` for the duration of the run — outside the scanned tree — and restore it afterwards. No in-tree artifact for plugin-check to see.

Regression from the wp-env hide step added in 0.11.0.